### PR TITLE
issue 22 replace method invocations with full zk paths

### DIFF
--- a/distributed-job-manager/src/main/java/ru/fix/distributed/job/manager/JobManagerPaths.java
+++ b/distributed-job-manager/src/main/java/ru/fix/distributed/job/manager/JobManagerPaths.java
@@ -3,16 +3,16 @@ package ru.fix.distributed.job.manager;
 import org.apache.curator.utils.ZKPaths;
 
 class JobManagerPaths {
-    public static final String ALIVE = "alive";
-    public static final String ASSIGNMENT_VERSION = "assignment-version";
-    public static final String LEADER_LATCH = "leader-latch";
-    public static final String LOCKS = "locks";
-    public static final String REGISTRATION_VERSION = "registration-version";
-    public static final String WORKERS = "workers";
-    public static final String ASSIGNED = "assigned";
-    public static final String AVAILABLE = "available";
-    public static final String WORK_POOLED_JOB_ID = "work-pooled";
-    public static final String WORK_POOL = "work-pool";
+    private static final String ALIVE = "alive";
+    private static final String ASSIGNMENT_VERSION = "assignment-version";
+    private static final String LEADER_LATCH = "leader-latch";
+    private static final String LOCKS = "locks";
+    private static final String REGISTRATION_VERSION = "registration-version";
+    private static final String WORKERS = "workers";
+    private static final String ASSIGNED = "assigned";
+    private static final String AVAILABLE = "available";
+    private static final String WORK_POOLED_JOB_ID = "work-pooled";
+    private static final String WORK_POOL = "work-pool";
 
     final String rootPath;
 

--- a/distributed-job-manager/src/main/java/ru/fix/distributed/job/manager/JobManagerPaths.java
+++ b/distributed-job-manager/src/main/java/ru/fix/distributed/job/manager/JobManagerPaths.java
@@ -3,10 +3,16 @@ package ru.fix.distributed.job.manager;
 import org.apache.curator.utils.ZKPaths;
 
 class JobManagerPaths {
+    public static final String ALIVE = "alive";
+    public static final String ASSIGNMENT_VERSION = "assignment-version";
+    public static final String LEADER_LATCH = "leader-latch";
+    public static final String LOCKS = "locks";
+    public static final String REGISTRATION_VERSION = "registration-version";
+    public static final String WORKERS = "workers";
+    public static final String ASSIGNED = "assigned";
+    public static final String AVAILABLE = "available";
     public static final String WORK_POOLED_JOB_ID = "work-pooled";
     public static final String WORK_POOL = "work-pool";
-    public static final String REGISTRATION_VERSION = "registration-version";
-    public static final String ASSIGNMENT_VERSION = "assignment-version";
 
     final String rootPath;
 
@@ -14,8 +20,29 @@ class JobManagerPaths {
         this.rootPath = rootPath;
     }
 
+    public String getWorkersAlivePath() {
+        return ZKPaths.makePath(rootPath, ALIVE);
+    }
+
+    String getWorkerAliveFlagPath(String workerId) {
+        return ZKPaths.makePath(rootPath, ALIVE, workerId);
+    }
+
     String getAssignmentVersion() {
         return ZKPaths.makePath(rootPath, ASSIGNMENT_VERSION);
+    }
+
+    String getLeaderLatchPath() {
+        return ZKPaths.makePath(rootPath, LEADER_LATCH);
+    }
+
+    String getWorkPooledLocksPath() {
+        return ZKPaths.makePath(rootPath, LOCKS, WORK_POOLED_JOB_ID);
+    }
+
+    String getWorkItemLock(String jobId, String workItem) {
+        return ZKPaths.makePath(rootPath, LOCKS, WORK_POOLED_JOB_ID, jobId,
+                String.format("work-share-%s.lock", workItem));
     }
 
     String getRegistrationVersion() {
@@ -23,68 +50,47 @@ class JobManagerPaths {
     }
 
     String getWorkersPath() {
-        return ZKPaths.makePath(rootPath, "workers");
-    }
-
-    String getWorkerAliveFlagPath(String workerId) {
-        return ZKPaths.makePath(getWorkersAlivePath(), workerId);
+        return ZKPaths.makePath(rootPath, WORKERS);
     }
 
     String getWorkerPath(String workerId) {
-        return ZKPaths.makePath(getWorkersPath(), workerId);
+        return ZKPaths.makePath(rootPath, WORKERS, workerId);
     }
 
-    String getWorkerAvailableJobsPath(String worker) {
-        return ZKPaths.makePath(getWorkerPath(worker), "available");
-    }
-
-    String getWorkerAssignedJobsPath(String worker) {
-        return ZKPaths.makePath(getWorkerPath(worker), "assigned");
-    }
-
-    String getLeaderLatchPath() {
-        return ZKPaths.makePath(rootPath, "leader-latch");
-    }
-
-    public String getWorkersAlivePath() {
-        return ZKPaths.makePath(rootPath, "alive");
-    }
-
-    String getAvailableWorkPooledJobPath(String workerId) {
-        return ZKPaths.makePath(getWorkerPath(workerId), "available", WORK_POOLED_JOB_ID);
-    }
-
-    String getAvailableWorkPoolPath(String workerId, String jobId) {
-        return ZKPaths.makePath(getAvailableWorkPooledJobPath(workerId), jobId, WORK_POOL);
+    String getWorkerAssignedJobsPath(String workerId) {
+        return ZKPaths.makePath(rootPath, WORKERS, workerId, ASSIGNED);
     }
 
     String getAssignedWorkPoolPath(String workerId, String jobId) {
-        return ZKPaths.makePath(getAssignedWorkPooledJobsPath(workerId), jobId, WORK_POOL);
+        return ZKPaths.makePath(rootPath, WORKERS, workerId, ASSIGNED, WORK_POOLED_JOB_ID, jobId, WORK_POOL);
     }
 
     String getAssignedWorkPooledJobsPath(String workerId) {
-        return ZKPaths.makePath(getWorkersPath(), workerId, "assigned", WORK_POOLED_JOB_ID);
+        return ZKPaths.makePath(rootPath, WORKERS, workerId, ASSIGNED, WORK_POOLED_JOB_ID);
     }
 
     String getAssignedWorkPooledJobsPath(String workerId, String jobId) {
-        return ZKPaths.makePath(getAssignedWorkPooledJobsPath(workerId), jobId);
-    }
-
-    String getAvailableWorkItemPath(String workerId, String jobId, String workItemId) {
-        return ZKPaths.makePath(getAvailableWorkPoolPath(workerId, jobId), workItemId);
+        return ZKPaths.makePath(rootPath, WORKERS, workerId, ASSIGNED, WORK_POOLED_JOB_ID, jobId);
     }
 
     String getAssignedWorkItemPath(String workerId, String jobId, String workItemId) {
-        return ZKPaths.makePath(getAssignedWorkPoolPath(workerId, jobId), workItemId);
+        return ZKPaths.makePath(rootPath, WORKERS, workerId, ASSIGNED, WORK_POOLED_JOB_ID, jobId, WORK_POOL, workItemId);
     }
 
-    String getWorkPooledLocksPath() {
-        return ZKPaths.makePath(rootPath, "locks", WORK_POOLED_JOB_ID);
+    String getWorkerAvailableJobsPath(String workerId) {
+        return ZKPaths.makePath(rootPath, WORKERS, workerId, AVAILABLE);
     }
 
-    String getWorkItemLock(String jobId, String workItem) {
-        return ZKPaths.makePath(rootPath, "locks", WORK_POOLED_JOB_ID, jobId,
-                String.format("work-share-%s.lock", workItem));
+    String getAvailableWorkPooledJobPath(String workerId) {
+        return ZKPaths.makePath(rootPath, WORKERS, workerId, AVAILABLE, WORK_POOLED_JOB_ID);
+    }
+
+    String getAvailableWorkPoolPath(String workerId, String jobId) {
+        return ZKPaths.makePath(rootPath, WORKERS, workerId, AVAILABLE, WORK_POOLED_JOB_ID, jobId, WORK_POOL);
+    }
+
+    String getAvailableWorkItemPath(String workerId, String jobId, String workItemId) {
+        return ZKPaths.makePath(rootPath, WORKERS, workerId, AVAILABLE, WORK_POOLED_JOB_ID, jobId, WORK_POOL, workItemId);
     }
 
 }

--- a/distributed-job-manager/src/main/java/ru/fix/distributed/job/manager/JobManagerPaths.java
+++ b/distributed-job-manager/src/main/java/ru/fix/distributed/job/manager/JobManagerPaths.java
@@ -61,16 +61,16 @@ class JobManagerPaths {
         return ZKPaths.makePath(rootPath, WORKERS, workerId, ASSIGNED);
     }
 
-    String getAssignedWorkPoolPath(String workerId, String jobId) {
-        return ZKPaths.makePath(rootPath, WORKERS, workerId, ASSIGNED, WORK_POOLED_JOB_ID, jobId, WORK_POOL);
-    }
-
     String getAssignedWorkPooledJobsPath(String workerId) {
         return ZKPaths.makePath(rootPath, WORKERS, workerId, ASSIGNED, WORK_POOLED_JOB_ID);
     }
 
     String getAssignedWorkPooledJobsPath(String workerId, String jobId) {
         return ZKPaths.makePath(rootPath, WORKERS, workerId, ASSIGNED, WORK_POOLED_JOB_ID, jobId);
+    }
+
+    String getAssignedWorkPoolPath(String workerId, String jobId) {
+        return ZKPaths.makePath(rootPath, WORKERS, workerId, ASSIGNED, WORK_POOLED_JOB_ID, jobId, WORK_POOL);
     }
 
     String getAssignedWorkItemPath(String workerId, String jobId, String workItemId) {

--- a/distributed-job-manager/src/main/java/ru/fix/distributed/job/manager/JobManagerPaths.java
+++ b/distributed-job-manager/src/main/java/ru/fix/distributed/job/manager/JobManagerPaths.java
@@ -21,76 +21,82 @@ class JobManagerPaths {
     }
 
     public String getWorkersAlivePath() {
-        return ZKPaths.makePath(rootPath, ALIVE);
+        return path(ALIVE);
     }
 
     String getWorkerAliveFlagPath(String workerId) {
-        return ZKPaths.makePath(rootPath, ALIVE, workerId);
+        return path(ALIVE, workerId);
     }
 
     String getAssignmentVersion() {
-        return ZKPaths.makePath(rootPath, ASSIGNMENT_VERSION);
+        return path(ASSIGNMENT_VERSION);
     }
 
     String getLeaderLatchPath() {
-        return ZKPaths.makePath(rootPath, LEADER_LATCH);
+        return path(LEADER_LATCH);
     }
 
     String getWorkPooledLocksPath() {
-        return ZKPaths.makePath(rootPath, LOCKS, WORK_POOLED_JOB_ID);
+        return path(LOCKS, WORK_POOLED_JOB_ID);
     }
 
     String getWorkItemLock(String jobId, String workItem) {
-        return ZKPaths.makePath(rootPath, LOCKS, WORK_POOLED_JOB_ID, jobId,
+        return path(LOCKS, WORK_POOLED_JOB_ID, jobId,
                 String.format("work-share-%s.lock", workItem));
     }
 
     String getRegistrationVersion() {
-        return ZKPaths.makePath(rootPath, REGISTRATION_VERSION);
+        return path(REGISTRATION_VERSION);
     }
 
     String getWorkersPath() {
-        return ZKPaths.makePath(rootPath, WORKERS);
+        return path(WORKERS);
     }
 
     String getWorkerPath(String workerId) {
-        return ZKPaths.makePath(rootPath, WORKERS, workerId);
+        return path(WORKERS, workerId);
     }
 
     String getWorkerAssignedJobsPath(String workerId) {
-        return ZKPaths.makePath(rootPath, WORKERS, workerId, ASSIGNED);
+        return path(WORKERS, workerId, ASSIGNED);
     }
 
     String getAssignedWorkPooledJobsPath(String workerId) {
-        return ZKPaths.makePath(rootPath, WORKERS, workerId, ASSIGNED, WORK_POOLED_JOB_ID);
+        return path(WORKERS, workerId, ASSIGNED, WORK_POOLED_JOB_ID);
     }
 
     String getAssignedWorkPooledJobsPath(String workerId, String jobId) {
-        return ZKPaths.makePath(rootPath, WORKERS, workerId, ASSIGNED, WORK_POOLED_JOB_ID, jobId);
+        return path(WORKERS, workerId, ASSIGNED, WORK_POOLED_JOB_ID, jobId);
     }
 
     String getAssignedWorkPoolPath(String workerId, String jobId) {
-        return ZKPaths.makePath(rootPath, WORKERS, workerId, ASSIGNED, WORK_POOLED_JOB_ID, jobId, WORK_POOL);
+        return path(WORKERS, workerId, ASSIGNED, WORK_POOLED_JOB_ID, jobId, WORK_POOL);
     }
 
     String getAssignedWorkItemPath(String workerId, String jobId, String workItemId) {
-        return ZKPaths.makePath(rootPath, WORKERS, workerId, ASSIGNED, WORK_POOLED_JOB_ID, jobId, WORK_POOL, workItemId);
+        return path(WORKERS, workerId, ASSIGNED, WORK_POOLED_JOB_ID, jobId, WORK_POOL, workItemId);
     }
 
     String getWorkerAvailableJobsPath(String workerId) {
-        return ZKPaths.makePath(rootPath, WORKERS, workerId, AVAILABLE);
+        return path(WORKERS, workerId, AVAILABLE);
     }
 
     String getAvailableWorkPooledJobPath(String workerId) {
-        return ZKPaths.makePath(rootPath, WORKERS, workerId, AVAILABLE, WORK_POOLED_JOB_ID);
+        return path(WORKERS, workerId, AVAILABLE, WORK_POOLED_JOB_ID);
     }
 
     String getAvailableWorkPoolPath(String workerId, String jobId) {
-        return ZKPaths.makePath(rootPath, WORKERS, workerId, AVAILABLE, WORK_POOLED_JOB_ID, jobId, WORK_POOL);
+        return path(WORKERS, workerId, AVAILABLE, WORK_POOLED_JOB_ID, jobId, WORK_POOL);
     }
 
     String getAvailableWorkItemPath(String workerId, String jobId, String workItemId) {
-        return ZKPaths.makePath(rootPath, WORKERS, workerId, AVAILABLE, WORK_POOLED_JOB_ID, jobId, WORK_POOL, workItemId);
+        return path(WORKERS, workerId, AVAILABLE, WORK_POOLED_JOB_ID, jobId, WORK_POOL, workItemId);
     }
 
+    private String path(String firstChild) {
+        return ZKPaths.makePath(rootPath, firstChild);
+    }
+    private String path(String firstChild, String... restChildren) {
+        return ZKPaths.makePath(rootPath, firstChild, restChildren);
+    }
 }

--- a/distributed-job-manager/src/main/java/ru/fix/distributed/job/manager/Manager.java
+++ b/distributed-job-manager/src/main/java/ru/fix/distributed/job/manager/Manager.java
@@ -221,12 +221,8 @@ class Manager implements AutoCloseable {
 
                 for (WorkItem workItem : job.getValue()) {
                     if (!previousState.containsWorkItemOnWorker(workerId, workItem)) {
-                        String newPath = ZKPaths.makePath(
-                                paths.getAssignedWorkPooledJobsPath(workerId.getId(), job.getKey().getId()),
-                                JobManagerPaths.WORK_POOL,
-                                workItem.getId()
-                        );
-                        transaction.createPath(newPath);
+                        transaction.createPath(paths
+                                .getAssignedWorkItemPath(workerId.getId(), job.getKey().getId(), workItem.getId()));
                     }
                 }
             }
@@ -239,12 +235,8 @@ class Manager implements AutoCloseable {
             for (Map.Entry<JobId, List<WorkItem>> job : jobs.entrySet()) {
                 for (WorkItem workItem : job.getValue()) {
                     if (!newAssignmentState.containsWorkItemOnWorker(workerId, workItem)) {
-                        String newPath = ZKPaths.makePath(
-                                paths.getAssignedWorkPooledJobsPath(workerId.getId(), job.getKey().getId()),
-                                JobManagerPaths.WORK_POOL,
-                                workItem.getId()
-                        );
-                        transaction.deletePathWithChildrenIfNeeded(newPath);
+                        transaction.deletePathWithChildrenIfNeeded(paths
+                                .getAssignedWorkItemPath(workerId.getId(), job.getKey().getId(), workItem.getId()));
                     }
                 }
             }


### PR DESCRIPTION
See https://github.com/ru-fix/distributed-job-manager/issues/22
It is more readable when you see the same paths tree in methods, as in ZK-web