### PR TITLE
issue 22 rename methods in job manager paths

### DIFF
--- a/distributed-job-manager/src/main/java/ru/fix/distributed/job/manager/DistributedJobManager.java
+++ b/distributed-job-manager/src/main/java/ru/fix/distributed/job/manager/DistributedJobManager.java
@@ -118,20 +118,20 @@ public class DistributedJobManager implements AutoCloseable {
 
     private static void initPaths(CuratorFramework curatorFramework, String rootPath) throws Exception {
         JobManagerPaths paths = new JobManagerPaths(rootPath);
-        if (curatorFramework.checkExists().forPath(paths.getWorkersPath()) == null) {
-            curatorFramework.create().creatingParentsIfNeeded().forPath(paths.getWorkersPath());
+        if (curatorFramework.checkExists().forPath(paths.toAllWorkers()) == null) {
+            curatorFramework.create().creatingParentsIfNeeded().forPath(paths.toAllWorkers());
         }
-        if (curatorFramework.checkExists().forPath(paths.getWorkersAlivePath()) == null) {
-            curatorFramework.create().creatingParentsIfNeeded().forPath(paths.getWorkersAlivePath());
+        if (curatorFramework.checkExists().forPath(paths.toAliveWorkers()) == null) {
+            curatorFramework.create().creatingParentsIfNeeded().forPath(paths.toAliveWorkers());
         }
-        if (curatorFramework.checkExists().forPath(paths.getRegistrationVersion()) == null) {
-            curatorFramework.create().creatingParentsIfNeeded().forPath(paths.getRegistrationVersion());
+        if (curatorFramework.checkExists().forPath(paths.toRegistrationVersion()) == null) {
+            curatorFramework.create().creatingParentsIfNeeded().forPath(paths.toRegistrationVersion());
         }
-        if (curatorFramework.checkExists().forPath(paths.getAssignmentVersion()) == null) {
-            curatorFramework.create().creatingParentsIfNeeded().forPath(paths.getAssignmentVersion());
+        if (curatorFramework.checkExists().forPath(paths.toAssignmentVersion()) == null) {
+            curatorFramework.create().creatingParentsIfNeeded().forPath(paths.toAssignmentVersion());
         }
-        if (curatorFramework.checkExists().forPath(paths.getWorkPooledLocksPath()) == null) {
-            curatorFramework.create().creatingParentsIfNeeded().forPath(paths.getWorkPooledLocksPath());
+        if (curatorFramework.checkExists().forPath(paths.toLocks()) == null) {
+            curatorFramework.create().creatingParentsIfNeeded().forPath(paths.toLocks());
         }
     }
 

--- a/distributed-job-manager/src/main/java/ru/fix/distributed/job/manager/DistributedJobManager.java
+++ b/distributed-job-manager/src/main/java/ru/fix/distributed/job/manager/DistributedJobManager.java
@@ -34,7 +34,7 @@ import java.util.Collection;
  * When job disappears from worker assigned/work-pooled path, worker stop executing job and release job lock.
  * </p>
  * <p>
- * ZK node tree managed by {@link DistributedJobManager} described in {@link JobManagerPaths}
+ * ZK node tree managed by {@link DistributedJobManager} described in {@link ZkPathsManager}
  * <pre>
  *
  * @author Kamil Asfandiyarov
@@ -117,7 +117,7 @@ public class DistributedJobManager implements AutoCloseable {
     }
 
     private static void initPaths(CuratorFramework curatorFramework, String rootPath) throws Exception {
-        JobManagerPaths paths = new JobManagerPaths(rootPath);
+        ZkPathsManager paths = new ZkPathsManager(rootPath);
         if (curatorFramework.checkExists().forPath(paths.toAllWorkers()) == null) {
             curatorFramework.create().creatingParentsIfNeeded().forPath(paths.toAllWorkers());
         }

--- a/distributed-job-manager/src/main/java/ru/fix/distributed/job/manager/DistributedJobManager.java
+++ b/distributed-job-manager/src/main/java/ru/fix/distributed/job/manager/DistributedJobManager.java
@@ -118,20 +118,20 @@ public class DistributedJobManager implements AutoCloseable {
 
     private static void initPaths(CuratorFramework curatorFramework, String rootPath) throws Exception {
         ZkPathsManager paths = new ZkPathsManager(rootPath);
-        if (curatorFramework.checkExists().forPath(paths.toAllWorkers()) == null) {
-            curatorFramework.create().creatingParentsIfNeeded().forPath(paths.toAllWorkers());
+        if (curatorFramework.checkExists().forPath(paths.allWorkers()) == null) {
+            curatorFramework.create().creatingParentsIfNeeded().forPath(paths.allWorkers());
         }
-        if (curatorFramework.checkExists().forPath(paths.toAliveWorkers()) == null) {
-            curatorFramework.create().creatingParentsIfNeeded().forPath(paths.toAliveWorkers());
+        if (curatorFramework.checkExists().forPath(paths.aliveWorkers()) == null) {
+            curatorFramework.create().creatingParentsIfNeeded().forPath(paths.aliveWorkers());
         }
-        if (curatorFramework.checkExists().forPath(paths.toRegistrationVersion()) == null) {
-            curatorFramework.create().creatingParentsIfNeeded().forPath(paths.toRegistrationVersion());
+        if (curatorFramework.checkExists().forPath(paths.registrationVersion()) == null) {
+            curatorFramework.create().creatingParentsIfNeeded().forPath(paths.registrationVersion());
         }
-        if (curatorFramework.checkExists().forPath(paths.toAssignmentVersion()) == null) {
-            curatorFramework.create().creatingParentsIfNeeded().forPath(paths.toAssignmentVersion());
+        if (curatorFramework.checkExists().forPath(paths.assignmentVersion()) == null) {
+            curatorFramework.create().creatingParentsIfNeeded().forPath(paths.assignmentVersion());
         }
-        if (curatorFramework.checkExists().forPath(paths.toLocks()) == null) {
-            curatorFramework.create().creatingParentsIfNeeded().forPath(paths.toLocks());
+        if (curatorFramework.checkExists().forPath(paths.locks()) == null) {
+            curatorFramework.create().creatingParentsIfNeeded().forPath(paths.locks());
         }
     }
 

--- a/distributed-job-manager/src/main/java/ru/fix/distributed/job/manager/JobManagerPaths.java
+++ b/distributed-job-manager/src/main/java/ru/fix/distributed/job/manager/JobManagerPaths.java
@@ -3,10 +3,16 @@ package ru.fix.distributed.job.manager;
 import org.apache.curator.utils.ZKPaths;
 
 class JobManagerPaths {
+    public static final String ALIVE = "alive";
+    public static final String ASSIGNMENT_VERSION = "assignment-version";
+    public static final String LEADER_LATCH = "leader-latch";
+    public static final String LOCKS = "locks";
+    public static final String REGISTRATION_VERSION = "registration-version";
+    public static final String WORKERS = "workers";
+    public static final String ASSIGNED = "assigned";
+    public static final String AVAILABLE = "available";
     public static final String WORK_POOLED_JOB_ID = "work-pooled";
     public static final String WORK_POOL = "work-pool";
-    public static final String REGISTRATION_VERSION = "registration-version";
-    public static final String ASSIGNMENT_VERSION = "assignment-version";
 
     final String rootPath;
 
@@ -14,8 +20,29 @@ class JobManagerPaths {
         this.rootPath = rootPath;
     }
 
+    public String getWorkersAlivePath() {
+        return ZKPaths.makePath(rootPath, ALIVE);
+    }
+
+    String getWorkerAliveFlagPath(String workerId) {
+        return ZKPaths.makePath(rootPath, ALIVE, workerId);
+    }
+
     String getAssignmentVersion() {
         return ZKPaths.makePath(rootPath, ASSIGNMENT_VERSION);
+    }
+
+    String getLeaderLatchPath() {
+        return ZKPaths.makePath(rootPath, LEADER_LATCH);
+    }
+
+    String getWorkPooledLocksPath() {
+        return ZKPaths.makePath(rootPath, LOCKS, WORK_POOLED_JOB_ID);
+    }
+
+    String getWorkItemLock(String jobId, String workItem) {
+        return ZKPaths.makePath(rootPath, LOCKS, WORK_POOLED_JOB_ID, jobId,
+                String.format("work-share-%s.lock", workItem));
     }
 
     String getRegistrationVersion() {
@@ -23,68 +50,47 @@ class JobManagerPaths {
     }
 
     String getWorkersPath() {
-        return ZKPaths.makePath(rootPath, "workers");
-    }
-
-    String getWorkerAliveFlagPath(String workerId) {
-        return ZKPaths.makePath(getWorkersAlivePath(), workerId);
+        return ZKPaths.makePath(rootPath, WORKERS);
     }
 
     String getWorkerPath(String workerId) {
-        return ZKPaths.makePath(getWorkersPath(), workerId);
+        return ZKPaths.makePath(rootPath, WORKERS, workerId);
     }
 
-    String getWorkerAvailableJobsPath(String worker) {
-        return ZKPaths.makePath(getWorkerPath(worker), "available");
-    }
-
-    String getWorkerAssignedJobsPath(String worker) {
-        return ZKPaths.makePath(getWorkerPath(worker), "assigned");
-    }
-
-    String getLeaderLatchPath() {
-        return ZKPaths.makePath(rootPath, "leader-latch");
-    }
-
-    public String getWorkersAlivePath() {
-        return ZKPaths.makePath(rootPath, "alive");
-    }
-
-    String getAvailableWorkPooledJobPath(String workerId) {
-        return ZKPaths.makePath(getWorkerPath(workerId), "available", WORK_POOLED_JOB_ID);
-    }
-
-    String getAvailableWorkPoolPath(String workerId, String jobId) {
-        return ZKPaths.makePath(getAvailableWorkPooledJobPath(workerId), jobId, WORK_POOL);
+    String getWorkerAssignedJobsPath(String workerId) {
+        return ZKPaths.makePath(rootPath, WORKERS, workerId, ASSIGNED);
     }
 
     String getAssignedWorkPoolPath(String workerId, String jobId) {
-        return ZKPaths.makePath(getAssignedWorkPooledJobsPath(workerId), jobId, WORK_POOL);
+        return ZKPaths.makePath(rootPath, WORKERS, workerId, ASSIGNED, WORK_POOLED_JOB_ID, jobId, WORK_POOL);
     }
 
     String getAssignedWorkPooledJobsPath(String workerId) {
-        return ZKPaths.makePath(getWorkersPath(), workerId, "assigned", WORK_POOLED_JOB_ID);
+        return ZKPaths.makePath(rootPath, WORKERS, workerId, ASSIGNED, WORK_POOLED_JOB_ID);
     }
 
     String getAssignedWorkPooledJobsPath(String workerId, String jobId) {
-        return ZKPaths.makePath(getAssignedWorkPooledJobsPath(workerId), jobId);
-    }
-
-    String getAvailableWorkItemPath(String workerId, String jobId, String workItemId) {
-        return ZKPaths.makePath(getAvailableWorkPoolPath(workerId, jobId), workItemId);
+        return ZKPaths.makePath(rootPath, WORKERS, workerId, ASSIGNED, WORK_POOLED_JOB_ID, jobId);
     }
 
     String getAssignedWorkItemPath(String workerId, String jobId, String workItemId) {
-        return ZKPaths.makePath(getAssignedWorkPoolPath(workerId, jobId), workItemId);
+        return ZKPaths.makePath(rootPath, WORKERS, workerId, ASSIGNED, WORK_POOLED_JOB_ID, jobId, WORK_POOL, workItemId);
     }
 
-    String getWorkPooledLocksPath() {
-        return ZKPaths.makePath(rootPath, "locks", WORK_POOLED_JOB_ID);
+    String getWorkerAvailableJobsPath(String workerId) {
+        return ZKPaths.makePath(rootPath, WORKERS, workerId, AVAILABLE);
     }
 
-    String getWorkItemLock(String jobId, String workItem) {
-        return ZKPaths.makePath(rootPath, "locks", WORK_POOLED_JOB_ID, jobId,
-                String.format("work-share-%s.lock", workItem));
+    String getAvailableWorkPooledJobPath(String workerId) {
+        return ZKPaths.makePath(rootPath, WORKERS, workerId, AVAILABLE, WORK_POOLED_JOB_ID);
+    }
+
+    String getAvailableWorkPoolPath(String workerId, String jobId) {
+        return ZKPaths.makePath(rootPath, WORKERS, workerId, AVAILABLE, WORK_POOLED_JOB_ID, jobId, WORK_POOL);
+    }
+
+    String getAvailableWorkItemPath(String workerId, String jobId, String workItemId) {
+        return ZKPaths.makePath(rootPath, WORKERS, workerId, AVAILABLE, WORK_POOLED_JOB_ID, jobId, WORK_POOL, workItemId);
     }
 
 }

--- a/distributed-job-manager/src/main/java/ru/fix/distributed/job/manager/JobManagerPaths.java
+++ b/distributed-job-manager/src/main/java/ru/fix/distributed/job/manager/JobManagerPaths.java
@@ -61,16 +61,16 @@ class JobManagerPaths {
         return ZKPaths.makePath(rootPath, WORKERS, workerId, ASSIGNED);
     }
 
-    String getAssignedWorkPoolPath(String workerId, String jobId) {
-        return ZKPaths.makePath(rootPath, WORKERS, workerId, ASSIGNED, WORK_POOLED_JOB_ID, jobId, WORK_POOL);
-    }
-
     String getAssignedWorkPooledJobsPath(String workerId) {
         return ZKPaths.makePath(rootPath, WORKERS, workerId, ASSIGNED, WORK_POOLED_JOB_ID);
     }
 
     String getAssignedWorkPooledJobsPath(String workerId, String jobId) {
         return ZKPaths.makePath(rootPath, WORKERS, workerId, ASSIGNED, WORK_POOLED_JOB_ID, jobId);
+    }
+
+    String getAssignedWorkPoolPath(String workerId, String jobId) {
+        return ZKPaths.makePath(rootPath, WORKERS, workerId, ASSIGNED, WORK_POOLED_JOB_ID, jobId, WORK_POOL);
     }
 
     String getAssignedWorkItemPath(String workerId, String jobId, String workItemId) {

--- a/distributed-job-manager/src/main/java/ru/fix/distributed/job/manager/JobManagerPaths.java
+++ b/distributed-job-manager/src/main/java/ru/fix/distributed/job/manager/JobManagerPaths.java
@@ -20,76 +20,76 @@ class JobManagerPaths {
         this.rootPath = rootPath;
     }
 
-    public String getWorkersAlivePath() {
+    public String toAliveWorkers() {
         return ZKPaths.makePath(rootPath, ALIVE);
     }
 
-    String getWorkerAliveFlagPath(String workerId) {
+    String toAliveWorker(String workerId) {
         return ZKPaths.makePath(rootPath, ALIVE, workerId);
     }
 
-    String getAssignmentVersion() {
+    String toAssignmentVersion() {
         return ZKPaths.makePath(rootPath, ASSIGNMENT_VERSION);
     }
 
-    String getLeaderLatchPath() {
+    String toLeaderLatch() {
         return ZKPaths.makePath(rootPath, LEADER_LATCH);
     }
 
-    String getWorkPooledLocksPath() {
+    String toLocks() {
         return ZKPaths.makePath(rootPath, LOCKS, WORK_POOLED_JOB_ID);
     }
 
-    String getWorkItemLock(String jobId, String workItem) {
+    String toWorkItemLock(String jobId, String workItem) {
         return ZKPaths.makePath(rootPath, LOCKS, WORK_POOLED_JOB_ID, jobId,
                 String.format("work-share-%s.lock", workItem));
     }
 
-    String getRegistrationVersion() {
+    String toRegistrationVersion() {
         return ZKPaths.makePath(rootPath, REGISTRATION_VERSION);
     }
 
-    String getWorkersPath() {
+    String toAllWorkers() {
         return ZKPaths.makePath(rootPath, WORKERS);
     }
 
-    String getWorkerPath(String workerId) {
+    String toWorker(String workerId) {
         return ZKPaths.makePath(rootPath, WORKERS, workerId);
     }
 
-    String getWorkerAssignedJobsPath(String workerId) {
+    String toAssignedWorkPool(String workerId) {
         return ZKPaths.makePath(rootPath, WORKERS, workerId, ASSIGNED);
     }
 
-    String getAssignedWorkPooledJobsPath(String workerId) {
+    String toAssignedJobs(String workerId) {
         return ZKPaths.makePath(rootPath, WORKERS, workerId, ASSIGNED, WORK_POOLED_JOB_ID);
     }
 
-    String getAssignedWorkPooledJobsPath(String workerId, String jobId) {
+    String toAssignedWorkPool(String workerId, String jobId) {
         return ZKPaths.makePath(rootPath, WORKERS, workerId, ASSIGNED, WORK_POOLED_JOB_ID, jobId);
     }
 
-    String getAssignedWorkPoolPath(String workerId, String jobId) {
+    String toAssignedWorkItems(String workerId, String jobId) {
         return ZKPaths.makePath(rootPath, WORKERS, workerId, ASSIGNED, WORK_POOLED_JOB_ID, jobId, WORK_POOL);
     }
 
-    String getAssignedWorkItemPath(String workerId, String jobId, String workItemId) {
+    String toAssignedWorkItem(String workerId, String jobId, String workItemId) {
         return ZKPaths.makePath(rootPath, WORKERS, workerId, ASSIGNED, WORK_POOLED_JOB_ID, jobId, WORK_POOL, workItemId);
     }
 
-    String getWorkerAvailableJobsPath(String workerId) {
+    String toAvailableWorkPool(String workerId) {
         return ZKPaths.makePath(rootPath, WORKERS, workerId, AVAILABLE);
     }
 
-    String getAvailableWorkPooledJobPath(String workerId) {
+    String toAvailableJobs(String workerId) {
         return ZKPaths.makePath(rootPath, WORKERS, workerId, AVAILABLE, WORK_POOLED_JOB_ID);
     }
 
-    String getAvailableWorkPoolPath(String workerId, String jobId) {
+    String toAvailableWorkItems(String workerId, String jobId) {
         return ZKPaths.makePath(rootPath, WORKERS, workerId, AVAILABLE, WORK_POOLED_JOB_ID, jobId, WORK_POOL);
     }
 
-    String getAvailableWorkItemPath(String workerId, String jobId, String workItemId) {
+    String toAvailableWorkItem(String workerId, String jobId, String workItemId) {
         return ZKPaths.makePath(rootPath, WORKERS, workerId, AVAILABLE, WORK_POOLED_JOB_ID, jobId, WORK_POOL, workItemId);
     }
 

--- a/distributed-job-manager/src/main/java/ru/fix/distributed/job/manager/Manager.java
+++ b/distributed-job-manager/src/main/java/ru/fix/distributed/job/manager/Manager.java
@@ -5,7 +5,6 @@ import org.apache.curator.framework.imps.CuratorFrameworkState;
 import org.apache.curator.framework.recipes.cache.PathChildrenCache;
 import org.apache.curator.framework.recipes.leader.LeaderLatch;
 import org.apache.curator.framework.recipes.leader.LeaderLatchListener;
-import org.apache.curator.utils.ZKPaths;
 import org.apache.zookeeper.KeeperException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,7 +34,7 @@ class Manager implements AutoCloseable {
     private static final int ASSIGNMENT_COMMIT_RETRIES_COUNT = 3;
 
     private final CuratorFramework curatorFramework;
-    private final JobManagerPaths paths;
+    private final ZkPathsManager paths;
     private final AssignmentStrategy assignmentStrategy;
 
     private PathChildrenCache workersAliveChildrenCache;
@@ -52,7 +51,7 @@ class Manager implements AutoCloseable {
     ) {
         this.managerThread = NamedExecutors.newSingleThreadPool("distributed-manager-thread", profiler);
         this.curatorFramework = curatorFramework;
-        this.paths = new JobManagerPaths(rootPath);
+        this.paths = new ZkPathsManager(rootPath);
         this.assignmentStrategy = assignmentStrategy;
         this.leaderLatch = initLeaderLatch();
         this.workersAliveChildrenCache = new PathChildrenCache(

--- a/distributed-job-manager/src/main/java/ru/fix/distributed/job/manager/Manager.java
+++ b/distributed-job-manager/src/main/java/ru/fix/distributed/job/manager/Manager.java
@@ -211,10 +211,10 @@ class Manager implements AutoCloseable {
                 continue;
             }
             for (Map.Entry<JobId, List<WorkItem>> job : jobs.entrySet()) {
-                createIfNotExist(transaction, paths.assignedWorkPool(
+                createIfNotExist(transaction, paths.assignedJob(
                         workerId.getId(), job.getKey().getId())
                 );
-                createIfNotExist(transaction, paths.assignedWorkItems(
+                createIfNotExist(transaction, paths.assignedWorkPool(
                         workerId.getId(), job.getKey().getId())
                 );
 
@@ -291,7 +291,7 @@ class Manager implements AutoCloseable {
             HashSet<WorkItem> assignedWorkPool = new HashSet<>();
             for (String assignedJobId : assignedJobIds) {
                 List<String> assignedJobWorkItems = curatorFramework.getChildren()
-                        .forPath(paths.assignedWorkItems(worker, assignedJobId));
+                        .forPath(paths.assignedWorkPool(worker, assignedJobId));
 
                 for (String workItem : assignedJobWorkItems) {
                     assignedWorkPool.add(new WorkItem(workItem, new JobId(assignedJobId)));
@@ -311,7 +311,7 @@ class Manager implements AutoCloseable {
             HashSet<WorkItem> availableWorkPool = new HashSet<>();
             for (String availableJobId : availableJobIds) {
                 List<String> workItemsForAvailableJobList = curatorFramework.getChildren()
-                        .forPath(paths.availableWorkItems(worker, availableJobId));
+                        .forPath(paths.availableWorkPool(worker, availableJobId));
 
                 for (String workItem : workItemsForAvailableJobList) {
                     availableWorkPool.add(new WorkItem(workItem, new JobId(availableJobId)));

--- a/distributed-job-manager/src/main/java/ru/fix/distributed/job/manager/Manager.java
+++ b/distributed-job-manager/src/main/java/ru/fix/distributed/job/manager/Manager.java
@@ -56,7 +56,7 @@ class Manager implements AutoCloseable {
         this.leaderLatch = initLeaderLatch();
         this.workersAliveChildrenCache = new PathChildrenCache(
                 curatorFramework,
-                paths.toAliveWorkers(),
+                paths.aliveWorkers(),
                 false);
         this.nodeId = nodeId;
     }
@@ -94,7 +94,7 @@ class Manager implements AutoCloseable {
     }
 
     private LeaderLatch initLeaderLatch() {
-        LeaderLatch latch = new LeaderLatch(curatorFramework, paths.toLeaderLatch());
+        LeaderLatch latch = new LeaderLatch(curatorFramework, paths.leaderLatch());
         latch.addListener(new LeaderLatchListener() {
             @Override
             public void isLeader() {
@@ -136,7 +136,7 @@ class Manager implements AutoCloseable {
                     curatorFramework,
                     ASSIGNMENT_COMMIT_RETRIES_COUNT,
                     transaction -> {
-                        String assignmentVersionNode = paths.toAssignmentVersion();
+                        String assignmentVersionNode = paths.assignmentVersion();
 
                         int version = curatorFramework.checkExists().forPath(assignmentVersionNode).getVersion();
 
@@ -207,21 +207,21 @@ class Manager implements AutoCloseable {
             Map<JobId, List<WorkItem>> jobs = itemsToMap(worker.getValue());
 
             if (curatorFramework.checkExists()
-                    .forPath(paths.toAliveWorker(workerId.getId())) == null) {
+                    .forPath(paths.aliveWorker(workerId.getId())) == null) {
                 continue;
             }
             for (Map.Entry<JobId, List<WorkItem>> job : jobs.entrySet()) {
-                createIfNotExist(transaction, paths.toAssignedWorkPool(
+                createIfNotExist(transaction, paths.assignedWorkPool(
                         workerId.getId(), job.getKey().getId())
                 );
-                createIfNotExist(transaction, paths.toAssignedWorkItems(
+                createIfNotExist(transaction, paths.assignedWorkItems(
                         workerId.getId(), job.getKey().getId())
                 );
 
                 for (WorkItem workItem : job.getValue()) {
                     if (!previousState.containsWorkItemOnWorker(workerId, workItem)) {
                         transaction.createPath(paths
-                                .toAssignedWorkItem(workerId.getId(), job.getKey().getId(), workItem.getId()));
+                                .assignedWorkItem(workerId.getId(), job.getKey().getId(), workItem.getId()));
                     }
                 }
             }
@@ -235,7 +235,7 @@ class Manager implements AutoCloseable {
                 for (WorkItem workItem : job.getValue()) {
                     if (!newAssignmentState.containsWorkItemOnWorker(workerId, workItem)) {
                         transaction.deletePathWithChildrenIfNeeded(paths
-                                .toAssignedWorkItem(workerId.getId(), job.getKey().getId(), workItem.getId()));
+                                .assignedWorkItem(workerId.getId(), job.getKey().getId(), workItem.getId()));
                     }
                 }
             }
@@ -249,16 +249,16 @@ class Manager implements AutoCloseable {
     }
 
     private void removeAssignmentsOnDeadNodes(TransactionalClient transaction) throws Exception {
-        List<String> workersRoots = curatorFramework.getChildren().forPath(paths.toAllWorkers());
+        List<String> workersRoots = curatorFramework.getChildren().forPath(paths.allWorkers());
 
         for (String worker : workersRoots) {
-            if (curatorFramework.checkExists().forPath(paths.toAliveWorker(worker)) != null) {
+            if (curatorFramework.checkExists().forPath(paths.aliveWorker(worker)) != null) {
                 continue;
             }
             log.info("nodeId={} Remove dead worker {}", nodeId, worker);
 
             try {
-                transaction.deletePathWithChildrenIfNeeded(paths.toWorker(worker));
+                transaction.deletePathWithChildrenIfNeeded(paths.worker(worker));
             } catch (KeeperException.NoNodeException e) {
                 log.info("Node was already deleted", e);
             }
@@ -279,19 +279,19 @@ class Manager implements AutoCloseable {
         AssignmentState assignedState = new AssignmentState();
 
         List<String> workersRoots = curatorFramework.getChildren()
-                .forPath(paths.toAllWorkers());
+                .forPath(paths.allWorkers());
 
         for (String worker : workersRoots) {
-            if (curatorFramework.checkExists().forPath(paths.toAliveWorker(worker)) == null) {
+            if (curatorFramework.checkExists().forPath(paths.aliveWorker(worker)) == null) {
                 continue;
             }
             List<String> assignedJobIds = curatorFramework.getChildren()
-                    .forPath(paths.toAssignedJobs(worker));
+                    .forPath(paths.assignedJobs(worker));
 
             HashSet<WorkItem> assignedWorkPool = new HashSet<>();
             for (String assignedJobId : assignedJobIds) {
                 List<String> assignedJobWorkItems = curatorFramework.getChildren()
-                        .forPath(paths.toAssignedWorkItems(worker, assignedJobId));
+                        .forPath(paths.assignedWorkItems(worker, assignedJobId));
 
                 for (String workItem : assignedJobWorkItems) {
                     assignedWorkPool.add(new WorkItem(workItem, new JobId(assignedJobId)));
@@ -301,17 +301,17 @@ class Manager implements AutoCloseable {
         }
 
         for (String worker : workersRoots) {
-            if (curatorFramework.checkExists().forPath(paths.toAliveWorker(worker)) == null) {
+            if (curatorFramework.checkExists().forPath(paths.aliveWorker(worker)) == null) {
                 continue;
             }
 
             List<String> availableJobIds = curatorFramework.getChildren()
-                    .forPath(paths.toAvailableJobs(worker));
+                    .forPath(paths.availableJobs(worker));
 
             HashSet<WorkItem> availableWorkPool = new HashSet<>();
             for (String availableJobId : availableJobIds) {
                 List<String> workItemsForAvailableJobList = curatorFramework.getChildren()
-                        .forPath(paths.toAvailableWorkItems(worker, availableJobId));
+                        .forPath(paths.availableWorkItems(worker, availableJobId));
 
                 for (String workItem : workItemsForAvailableJobList) {
                     availableWorkPool.add(new WorkItem(workItem, new JobId(availableJobId)));

--- a/distributed-job-manager/src/main/java/ru/fix/distributed/job/manager/WorkShareLockServiceImpl.java
+++ b/distributed-job-manager/src/main/java/ru/fix/distributed/job/manager/WorkShareLockServiceImpl.java
@@ -99,7 +99,7 @@ public class WorkShareLockServiceImpl implements AutoCloseable, WorkShareLockSer
 
         PersistentExpiringDistributedLock lock;
         try {
-            String lockPath = jobManagerPaths.getWorkItemLock(job.getJobId(), workItem);
+            String lockPath = jobManagerPaths.toWorkItemLock(job.getJobId(), workItem);
             lock = new PersistentExpiringDistributedLock(
                     curatorFramework,
                     persistenLockExecutor,

--- a/distributed-job-manager/src/main/java/ru/fix/distributed/job/manager/WorkShareLockServiceImpl.java
+++ b/distributed-job-manager/src/main/java/ru/fix/distributed/job/manager/WorkShareLockServiceImpl.java
@@ -31,7 +31,7 @@ public class WorkShareLockServiceImpl implements AutoCloseable, WorkShareLockSer
 
 
     final CuratorFramework curatorFramework;
-    final JobManagerPaths jobManagerPaths;
+    final ZkPathsManager zkPathsManager;
     final String workerId;
     final ExecutorService persistenLockExecutor;
 
@@ -64,7 +64,7 @@ public class WorkShareLockServiceImpl implements AutoCloseable, WorkShareLockSer
     final Map<DistributedJob, Map<String, WorkItemLock>> jobWorkItemLocks = new ConcurrentHashMap<>();
 
     public WorkShareLockServiceImpl(CuratorFramework curatorFramework,
-                                    JobManagerPaths jobManagerPaths,
+                                    ZkPathsManager zkPathsManager,
                                     String workerId,
                                     Profiler profiler) {
 
@@ -73,7 +73,7 @@ public class WorkShareLockServiceImpl implements AutoCloseable, WorkShareLockSer
         persistenLockExecutor = NamedExecutors.newSingleThreadPool(
                 "djm-work-item-persistent-lock-executor", profiler);
         this.curatorFramework = curatorFramework;
-        this.jobManagerPaths = jobManagerPaths;
+        this.zkPathsManager = zkPathsManager;
         this.workerId = workerId;
 
         this.workItemProlongationTask.schedule(
@@ -99,7 +99,7 @@ public class WorkShareLockServiceImpl implements AutoCloseable, WorkShareLockSer
 
         PersistentExpiringDistributedLock lock;
         try {
-            String lockPath = jobManagerPaths.toWorkItemLock(job.getJobId(), workItem);
+            String lockPath = zkPathsManager.toWorkItemLock(job.getJobId(), workItem);
             lock = new PersistentExpiringDistributedLock(
                     curatorFramework,
                     persistenLockExecutor,

--- a/distributed-job-manager/src/main/java/ru/fix/distributed/job/manager/WorkShareLockServiceImpl.java
+++ b/distributed-job-manager/src/main/java/ru/fix/distributed/job/manager/WorkShareLockServiceImpl.java
@@ -99,7 +99,7 @@ public class WorkShareLockServiceImpl implements AutoCloseable, WorkShareLockSer
 
         PersistentExpiringDistributedLock lock;
         try {
-            String lockPath = zkPathsManager.toWorkItemLock(job.getJobId(), workItem);
+            String lockPath = zkPathsManager.workItemLock(job.getJobId(), workItem);
             lock = new PersistentExpiringDistributedLock(
                     curatorFramework,
                     persistenLockExecutor,

--- a/distributed-job-manager/src/main/java/ru/fix/distributed/job/manager/Worker.java
+++ b/distributed-job-manager/src/main/java/ru/fix/distributed/job/manager/Worker.java
@@ -31,7 +31,7 @@ import java.util.stream.Collectors;
  * accordingly.
  *
  * @author Kamil Asfandiyarov
- * @see JobManagerPaths
+ * @see ZkPathsManager
  * @see Manager
  */
 class Worker implements AutoCloseable {
@@ -46,7 +46,7 @@ class Worker implements AutoCloseable {
     private final Collection<DistributedJob> availableJobs;
     private final ScheduledJobManager scheduledJobManager = new ScheduledJobManager();
 
-    private final JobManagerPaths paths;
+    private final ZkPathsManager paths;
     private final String workerId;
     private volatile TreeCache workPooledCache;
 
@@ -73,7 +73,7 @@ class Worker implements AutoCloseable {
            Profiler profiler,
            DynamicProperty<Long> timeToWaitTermination) {
         this.curatorFramework = curatorFramework;
-        this.paths = new JobManagerPaths(rootPath);
+        this.paths = new ZkPathsManager(rootPath);
         this.workerId = nodeId;
         this.availableJobs = distributedJobs;
 

--- a/distributed-job-manager/src/main/java/ru/fix/distributed/job/manager/Worker.java
+++ b/distributed-job-manager/src/main/java/ru/fix/distributed/job/manager/Worker.java
@@ -181,7 +181,7 @@ class Worker implements AutoCloseable {
                 WORKER_REGISTRATION_RETRIES_COUNT,
                 transaction -> {
                     // check node version
-                    String checkNodePath = paths.getRegistrationVersion();
+                    String checkNodePath = paths.toRegistrationVersion();
                     transaction.checkPath(checkNodePath);
 
                     transaction.setData(checkNodePath, new byte[]{});
@@ -189,40 +189,40 @@ class Worker implements AutoCloseable {
                     log.info("Registering worker {} (registration version {})", workerId, new byte[]{});
 
                     // register worker as alive
-                    String nodeAlivePath = paths.getWorkerAliveFlagPath(workerId);
+                    String nodeAlivePath = paths.toAliveWorker(workerId);
                     if (curatorFramework.checkExists().forPath(nodeAlivePath) != null) {
                         transaction.deletePath(nodeAlivePath);
                     }
                     transaction.createPathWithMode(nodeAlivePath, CreateMode.EPHEMERAL);
 
                     // clean up all available jobs
-                    String workerPath = paths.getWorkerPath(workerId);
+                    String workerPath = paths.toWorker(workerId);
                     if (curatorFramework.checkExists().forPath(workerPath) != null) {
                         transaction.deletePathWithChildrenIfNeeded(workerPath);
                     }
 
                     // create availability and assignments directories
-                    transaction.createPath(paths.getWorkerPath(workerId));
-                    transaction.createPath(paths.getWorkerAvailableJobsPath(workerId));
-                    transaction.createPath(paths.getAvailableWorkPooledJobPath(workerId));
-                    transaction.createPath(paths.getWorkerAssignedJobsPath(workerId));
-                    transaction.createPath(paths.getAssignedWorkPooledJobsPath(workerId));
+                    transaction.createPath(paths.toWorker(workerId));
+                    transaction.createPath(paths.toAvailableWorkPool(workerId));
+                    transaction.createPath(paths.toAvailableJobs(workerId));
+                    transaction.createPath(paths.toAssignedWorkPool(workerId));
+                    transaction.createPath(paths.toAssignedJobs(workerId));
 
                     // register work pooled jobs
                     for (DistributedJob job : availableJobs) {
                         transaction.createPath(
-                                ZKPaths.makePath(paths.getAvailableWorkPooledJobPath(workerId), job.getJobId()));
-                        transaction.createPath(paths.getAvailableWorkPoolPath(workerId, job.getJobId()));
+                                ZKPaths.makePath(paths.toAvailableJobs(workerId), job.getJobId()));
+                        transaction.createPath(paths.toAvailableWorkItems(workerId, job.getJobId()));
 
                         for (String workPool : workPools.get(job).getItems()) {
                             transaction.createPath(
-                                    ZKPaths.makePath(paths.getAvailableWorkPoolPath(workerId, job.getJobId()), workPool));
+                                    ZKPaths.makePath(paths.toAvailableWorkItems(workerId, job.getJobId()), workPool));
                         }
                     }
                 }
         );
 
-        workPooledCache = new TreeCache(curatorFramework, paths.getAssignedWorkPooledJobsPath(workerId));
+        workPooledCache = new TreeCache(curatorFramework, paths.toAssignedJobs(workerId));
         workPooledCache.getListenable().addListener((client, event) -> {
             log.info("wid={} registerWorkerAsAliveAndRegisterJobs event={}", workerId, event);
             switch (event.getType()) {
@@ -246,8 +246,8 @@ class Worker implements AutoCloseable {
 
     private void updateWorkPoolForJob(DistributedJob job, Set<String> newWorkPool) {
         try {
-            String workPoolsPath = paths.getAvailableWorkPoolPath(workerId, job.getJobId());
-            String workerAliveFlagPath = paths.getWorkerAliveFlagPath(workerId);
+            String workPoolsPath = paths.toAvailableWorkItems(workerId, job.getJobId());
+            String workerAliveFlagPath = paths.toAliveWorker(workerId);
 
             TransactionalClient.tryCommit(
                     curatorFramework,
@@ -265,7 +265,7 @@ class Worker implements AutoCloseable {
                                         currentWorkPools,
                                         newWorkPool);
 
-                                transaction.setData(paths.getWorkerAliveFlagPath(workerId),
+                                transaction.setData(paths.toAliveWorker(workerId),
                                         curatorFramework.getData().forPath(workerAliveFlagPath));
 
                                 Set<String> workPoolsToDelete = new HashSet<>(currentWorkPools);
@@ -403,7 +403,7 @@ class Worker implements AutoCloseable {
     private List<String> getWorkerWorkPool(DistributedJob job) throws Exception {
         try {
             return curatorFramework.getChildren()
-                    .forPath(paths.getAssignedWorkPoolPath(workerId, job.getJobId()));
+                    .forPath(paths.toAssignedWorkItems(workerId, job.getJobId()));
         } catch (KeeperException.NoNodeException e) {
             log.trace("Received event when NoNode for work pool path {}", e, e);
             return Collections.emptyList();
@@ -489,7 +489,7 @@ class Worker implements AutoCloseable {
 
         // remove node alive flag
         try {
-            String nodeAlivePath = paths.getWorkerAliveFlagPath(workerId);
+            String nodeAlivePath = paths.toAliveWorker(workerId);
             if (curatorFramework.checkExists().forPath(nodeAlivePath) != null) {
                 curatorFramework.delete().forPath(nodeAlivePath);
             }

--- a/distributed-job-manager/src/main/java/ru/fix/distributed/job/manager/Worker.java
+++ b/distributed-job-manager/src/main/java/ru/fix/distributed/job/manager/Worker.java
@@ -212,11 +212,11 @@ class Worker implements AutoCloseable {
                     for (DistributedJob job : availableJobs) {
                         transaction.createPath(
                                 ZKPaths.makePath(paths.availableJobs(workerId), job.getJobId()));
-                        transaction.createPath(paths.availableWorkItems(workerId, job.getJobId()));
+                        transaction.createPath(paths.availableWorkPool(workerId, job.getJobId()));
 
                         for (String workPool : workPools.get(job).getItems()) {
                             transaction.createPath(
-                                    ZKPaths.makePath(paths.availableWorkItems(workerId, job.getJobId()), workPool));
+                                    ZKPaths.makePath(paths.availableWorkPool(workerId, job.getJobId()), workPool));
                         }
                     }
                 }
@@ -246,7 +246,7 @@ class Worker implements AutoCloseable {
 
     private void updateWorkPoolForJob(DistributedJob job, Set<String> newWorkPool) {
         try {
-            String workPoolsPath = paths.availableWorkItems(workerId, job.getJobId());
+            String workPoolsPath = paths.availableWorkPool(workerId, job.getJobId());
             String workerAliveFlagPath = paths.aliveWorker(workerId);
 
             TransactionalClient.tryCommit(
@@ -403,7 +403,7 @@ class Worker implements AutoCloseable {
     private List<String> getWorkerWorkPool(DistributedJob job) throws Exception {
         try {
             return curatorFramework.getChildren()
-                    .forPath(paths.assignedWorkItems(workerId, job.getJobId()));
+                    .forPath(paths.assignedWorkPool(workerId, job.getJobId()));
         } catch (KeeperException.NoNodeException e) {
             log.trace("Received event when NoNode for work pool path {}", e, e);
             return Collections.emptyList();

--- a/distributed-job-manager/src/main/java/ru/fix/distributed/job/manager/ZkPathsManager.java
+++ b/distributed-job-manager/src/main/java/ru/fix/distributed/job/manager/ZkPathsManager.java
@@ -65,11 +65,11 @@ class ZkPathsManager {
         return path(WORKERS, workerId, ASSIGNED, WORK_POOLED_JOB_ID);
     }
 
-    String assignedWorkPool(String workerId, String jobId) {
+    String assignedJob(String workerId, String jobId) {
         return path(WORKERS, workerId, ASSIGNED, WORK_POOLED_JOB_ID, jobId);
     }
 
-    String assignedWorkItems(String workerId, String jobId) {
+    String assignedWorkPool(String workerId, String jobId) {
         return path(WORKERS, workerId, ASSIGNED, WORK_POOLED_JOB_ID, jobId, WORK_POOL);
     }
 
@@ -85,7 +85,7 @@ class ZkPathsManager {
         return path(WORKERS, workerId, AVAILABLE, WORK_POOLED_JOB_ID);
     }
 
-    String availableWorkItems(String workerId, String jobId) {
+    String availableWorkPool(String workerId, String jobId) {
         return path(WORKERS, workerId, AVAILABLE, WORK_POOLED_JOB_ID, jobId, WORK_POOL);
     }
 

--- a/distributed-job-manager/src/main/java/ru/fix/distributed/job/manager/ZkPathsManager.java
+++ b/distributed-job-manager/src/main/java/ru/fix/distributed/job/manager/ZkPathsManager.java
@@ -2,7 +2,7 @@ package ru.fix.distributed.job.manager;
 
 import org.apache.curator.utils.ZKPaths;
 
-class JobManagerPaths {
+class ZkPathsManager {
     private static final String ALIVE = "alive";
     private static final String ASSIGNMENT_VERSION = "assignment-version";
     private static final String LEADER_LATCH = "leader-latch";
@@ -16,7 +16,7 @@ class JobManagerPaths {
 
     final String rootPath;
 
-    JobManagerPaths(String rootPath) {
+    ZkPathsManager(String rootPath) {
         this.rootPath = rootPath;
     }
 

--- a/distributed-job-manager/src/main/java/ru/fix/distributed/job/manager/ZkPathsManager.java
+++ b/distributed-job-manager/src/main/java/ru/fix/distributed/job/manager/ZkPathsManager.java
@@ -20,76 +20,76 @@ class ZkPathsManager {
         this.rootPath = rootPath;
     }
 
-    public String toAliveWorkers() {
+    public String aliveWorkers() {
         return path(ALIVE);
     }
 
-    String toAliveWorker(String workerId) {
+    String aliveWorker(String workerId) {
         return path(ALIVE, workerId);
     }
 
-    String toAssignmentVersion() {
+    String assignmentVersion() {
         return path(ASSIGNMENT_VERSION);
     }
 
-    String toLeaderLatch() {
+    String leaderLatch() {
         return path(LEADER_LATCH);
     }
 
-    String toLocks() {
+    String locks() {
         return path(LOCKS, WORK_POOLED_JOB_ID);
     }
 
-    String toWorkItemLock(String jobId, String workItem) {
+    String workItemLock(String jobId, String workItem) {
         return path(LOCKS, WORK_POOLED_JOB_ID, jobId,
                 String.format("work-share-%s.lock", workItem));
     }
 
-    String toRegistrationVersion() {
+    String registrationVersion() {
         return path(REGISTRATION_VERSION);
     }
 
-    String toAllWorkers() {
+    String allWorkers() {
         return path(WORKERS);
     }
 
-    String toWorker(String workerId) {
+    String worker(String workerId) {
         return path(WORKERS, workerId);
     }
 
-    String toAssignedWorkPool(String workerId) {
+    String assignedWorkPool(String workerId) {
         return path(WORKERS, workerId, ASSIGNED);
     }
 
-    String toAssignedJobs(String workerId) {
+    String assignedJobs(String workerId) {
         return path(WORKERS, workerId, ASSIGNED, WORK_POOLED_JOB_ID);
     }
 
-    String toAssignedWorkPool(String workerId, String jobId) {
+    String assignedWorkPool(String workerId, String jobId) {
         return path(WORKERS, workerId, ASSIGNED, WORK_POOLED_JOB_ID, jobId);
     }
 
-    String toAssignedWorkItems(String workerId, String jobId) {
+    String assignedWorkItems(String workerId, String jobId) {
         return path(WORKERS, workerId, ASSIGNED, WORK_POOLED_JOB_ID, jobId, WORK_POOL);
     }
 
-    String toAssignedWorkItem(String workerId, String jobId, String workItemId) {
+    String assignedWorkItem(String workerId, String jobId, String workItemId) {
         return path(WORKERS, workerId, ASSIGNED, WORK_POOLED_JOB_ID, jobId, WORK_POOL, workItemId);
     }
 
-    String toAvailableWorkPool(String workerId) {
+    String availableWorkPool(String workerId) {
         return path(WORKERS, workerId, AVAILABLE);
     }
 
-    String toAvailableJobs(String workerId) {
+    String availableJobs(String workerId) {
         return path(WORKERS, workerId, AVAILABLE, WORK_POOLED_JOB_ID);
     }
 
-    String toAvailableWorkItems(String workerId, String jobId) {
+    String availableWorkItems(String workerId, String jobId) {
         return path(WORKERS, workerId, AVAILABLE, WORK_POOLED_JOB_ID, jobId, WORK_POOL);
     }
 
-    String toAvailableWorkItem(String workerId, String jobId, String workItemId) {
+    String availableWorkItem(String workerId, String jobId, String workItemId) {
         return path(WORKERS, workerId, AVAILABLE, WORK_POOLED_JOB_ID, jobId, WORK_POOL, workItemId);
     }
 

--- a/distributed-job-manager/src/test/java/ru/fix/distributed/job/manager/AbstractJobManagerTest.java
+++ b/distributed-job-manager/src/test/java/ru/fix/distributed/job/manager/AbstractJobManagerTest.java
@@ -25,7 +25,7 @@ public class AbstractJobManagerTest {
         zkTestingServer.start();
     }
 
-    JobManagerPaths paths = new JobManagerPaths(JOB_MANAGER_ZK_ROOT_PATH);
+    ZkPathsManager paths = new ZkPathsManager(JOB_MANAGER_ZK_ROOT_PATH);
 
     String printZkTree(String path) {
         return new ZkTreePrinter(zkTestingServer.getClient()).print(path);

--- a/distributed-job-manager/src/test/java/ru/fix/distributed/job/manager/WorkPooledMultiJobIT.java
+++ b/distributed-job-manager/src/test/java/ru/fix/distributed/job/manager/WorkPooledMultiJobIT.java
@@ -328,7 +328,7 @@ public class WorkPooledMultiJobIT extends AbstractJobManagerTest {
         StubbedMultiJob testJob = Mockito.spy(new StubbedMultiJob(10, getWorkItems(10)));
         AggregatingProfiler profiler = new AggregatingProfiler();
 
-        JobManagerPaths paths = new JobManagerPaths(JOB_MANAGER_ZK_ROOT_PATH);
+        ZkPathsManager paths = new ZkPathsManager(JOB_MANAGER_ZK_ROOT_PATH);
         // simulate hard shutdown where availability is not cleaned up
         String availableWorkpoolPath = paths.toAvailableWorkItems(nodeId, testJob.getJobId());
         zkTestingServer.getClient().create().creatingParentsIfNeeded().forPath(availableWorkpoolPath);

--- a/distributed-job-manager/src/test/java/ru/fix/distributed/job/manager/WorkPooledMultiJobIT.java
+++ b/distributed-job-manager/src/test/java/ru/fix/distributed/job/manager/WorkPooledMultiJobIT.java
@@ -45,7 +45,7 @@ public class WorkPooledMultiJobIT extends AbstractJobManagerTest {
                     () -> {
                         String jobId = getJobId(1);
                         Stat commonWorkerPoolChecker = zkTestingServer.getClient().checkExists()
-                                .forPath(ZKPaths.makePath(paths.getAvailableWorkPoolPath(nodeId, jobId),
+                                .forPath(ZKPaths.makePath(paths.toAvailableWorkItems(nodeId, jobId),
                                         "work-item-1.1"));
                         return commonWorkerPoolChecker != null;
                     },
@@ -68,7 +68,7 @@ public class WorkPooledMultiJobIT extends AbstractJobManagerTest {
                     () -> {
                         // Work pool contains 3 work items. Then every distributed job should contains 1 work item.
                         for (String nodeId : nodeIds) {
-                            String assignedWorkpoolPath = paths.getAssignedWorkPoolPath(nodeId, getJobId(1));
+                            String assignedWorkpoolPath = paths.toAssignedWorkItems(nodeId, getJobId(1));
                             if (curator.checkExists().forPath(assignedWorkpoolPath) != null) {
                                 List<String> workPool = curator.getChildren().forPath(assignedWorkpoolPath);
                                 if (workPool.contains(searchedWorkItem)) {
@@ -97,15 +97,15 @@ public class WorkPooledMultiJobIT extends AbstractJobManagerTest {
         ) {
             assertTimeout(Duration.ofMillis(30_000),
                     () -> {
-                        if (proxiedCurator.checkExists().forPath(paths.getAssignedWorkPoolPath(worker1, getJobId(1)))
+                        if (proxiedCurator.checkExists().forPath(paths.toAssignedWorkItems(worker1, getJobId(1)))
                                 != null &&
-                                proxiedCurator.checkExists().forPath(paths.getAssignedWorkPoolPath(worker2, getJobId
+                                proxiedCurator.checkExists().forPath(paths.toAssignedWorkItems(worker2, getJobId
                                         (1))) != null) {
                             Set<String> workItems = getWorkItems(1);
                             List<String> workPool1 = proxiedCurator.getChildren().forPath(paths
-                                    .getAssignedWorkPoolPath(worker1, getJobId(1)));
+                                    .toAssignedWorkItems(worker1, getJobId(1)));
                             List<String> workPool2 = proxiedCurator.getChildren().forPath(paths
-                                    .getAssignedWorkPoolPath(worker2, getJobId(1)));
+                                    .toAssignedWorkItems(worker2, getJobId(1)));
                             workItems.removeAll(workPool1);
                             workItems.removeAll(workPool2);
                             return workItems.isEmpty();
@@ -123,23 +123,23 @@ public class WorkPooledMultiJobIT extends AbstractJobManagerTest {
 
             assertTimeout(Duration.ofMillis(30_000),
                     () -> {
-                        if (zkTestingServer.getClient().checkExists().forPath(paths.getAssignedWorkPoolPath(worker2,
+                        if (zkTestingServer.getClient().checkExists().forPath(paths.toAssignedWorkItems(worker2,
                                 getJobId(1))) != null) {
                             Set<String> workItems = getWorkItems(1);
 
                             List<String> workPool1 = new ArrayList<>();
-                            if (zkTestingServer.getClient().checkExists().forPath(paths.getAssignedWorkPoolPath
+                            if (zkTestingServer.getClient().checkExists().forPath(paths.toAssignedWorkItems
                                     (worker1, getJobId(1))) != null) {
                                 try {
                                     workPool1.addAll(zkTestingServer.getClient().getChildren().forPath(paths
-                                            .getAssignedWorkPoolPath(worker1, getJobId(1))));
+                                            .toAssignedWorkItems(worker1, getJobId(1))));
                                 } catch (KeeperException.NoNodeException e) {
                                     // ignore this exception here
                                 }
                             }
 
                             List<String> workPool2 = zkTestingServer.getClient().getChildren().forPath(paths
-                                    .getAssignedWorkPoolPath(worker2, getJobId(1)));
+                                    .toAssignedWorkItems(worker2, getJobId(1)));
                             return workPool1.isEmpty() && workPool2.containsAll(workItems);
                         }
                         return false;
@@ -159,15 +159,15 @@ public class WorkPooledMultiJobIT extends AbstractJobManagerTest {
 
             assertTimeout(Duration.ofMillis(50_000),
                     () -> {
-                        if (proxiedCurator.checkExists().forPath(paths.getAssignedWorkPoolPath(worker1, getJobId(1)))
+                        if (proxiedCurator.checkExists().forPath(paths.toAssignedWorkItems(worker1, getJobId(1)))
                                 != null &&
-                                proxiedCurator.checkExists().forPath(paths.getAssignedWorkPoolPath(worker2, getJobId
+                                proxiedCurator.checkExists().forPath(paths.toAssignedWorkItems(worker2, getJobId
                                         (1))) != null) {
                             Set<String> workItems = getWorkItems(1);
                             List<String> workPool1 = proxiedCurator.getChildren().forPath(paths
-                                    .getAssignedWorkPoolPath(worker1, getJobId(1)));
+                                    .toAssignedWorkItems(worker1, getJobId(1)));
                             List<String> workPool2 = proxiedCurator.getChildren().forPath(paths
-                                    .getAssignedWorkPoolPath(worker2, getJobId(1)));
+                                    .toAssignedWorkItems(worker2, getJobId(1)));
                             workItems.removeAll(workPool1);
                             workItems.removeAll(workPool2);
                             return workItems.isEmpty() && !workPool1.isEmpty();
@@ -189,8 +189,8 @@ public class WorkPooledMultiJobIT extends AbstractJobManagerTest {
         ) {
             assertTimeout(Duration.ofMillis(10_000),
                     () -> {
-                        String pathForWorker1 = paths.getAssignedWorkPoolPath(nodeIds[0], getJobId(1));
-                        String pathForWorker2 = paths.getAssignedWorkPoolPath(nodeIds[1], getJobId(1));
+                        String pathForWorker1 = paths.toAssignedWorkItems(nodeIds[0], getJobId(1));
+                        String pathForWorker2 = paths.toAssignedWorkItems(nodeIds[1], getJobId(1));
 
                         if (curator.checkExists().forPath(pathForWorker1) != null && curator.checkExists().forPath
                                 (pathForWorker2) != null) {
@@ -330,7 +330,7 @@ public class WorkPooledMultiJobIT extends AbstractJobManagerTest {
 
         JobManagerPaths paths = new JobManagerPaths(JOB_MANAGER_ZK_ROOT_PATH);
         // simulate hard shutdown where availability is not cleaned up
-        String availableWorkpoolPath = paths.getAvailableWorkPoolPath(nodeId, testJob.getJobId());
+        String availableWorkpoolPath = paths.toAvailableWorkItems(nodeId, testJob.getJobId());
         zkTestingServer.getClient().create().creatingParentsIfNeeded().forPath(availableWorkpoolPath);
 
         try (
@@ -591,7 +591,7 @@ public class WorkPooledMultiJobIT extends AbstractJobManagerTest {
             assertTimeout(Duration.ofMillis(30_000),
                     () -> {
                         List<String> workPoolForFirstJob = curator2.getChildren()
-                                .forPath(paths.getAssignedWorkPoolPath(nodeIds[1], getJobId(1)));
+                                .forPath(paths.toAssignedWorkItems(nodeIds[1], getJobId(1)));
                         return workPoolForFirstJob.size() == getWorkItems(1).size();
                     },
                     () -> "All work pool should be distributed on 1 alive worker" + printZkTree

--- a/distributed-job-manager/src/test/java/ru/fix/distributed/job/manager/WorkPooledMultiJobIT.java
+++ b/distributed-job-manager/src/test/java/ru/fix/distributed/job/manager/WorkPooledMultiJobIT.java
@@ -45,7 +45,7 @@ public class WorkPooledMultiJobIT extends AbstractJobManagerTest {
                     () -> {
                         String jobId = getJobId(1);
                         Stat commonWorkerPoolChecker = zkTestingServer.getClient().checkExists()
-                                .forPath(ZKPaths.makePath(paths.toAvailableWorkItems(nodeId, jobId),
+                                .forPath(ZKPaths.makePath(paths.availableWorkItems(nodeId, jobId),
                                         "work-item-1.1"));
                         return commonWorkerPoolChecker != null;
                     },
@@ -68,7 +68,7 @@ public class WorkPooledMultiJobIT extends AbstractJobManagerTest {
                     () -> {
                         // Work pool contains 3 work items. Then every distributed job should contains 1 work item.
                         for (String nodeId : nodeIds) {
-                            String assignedWorkpoolPath = paths.toAssignedWorkItems(nodeId, getJobId(1));
+                            String assignedWorkpoolPath = paths.assignedWorkItems(nodeId, getJobId(1));
                             if (curator.checkExists().forPath(assignedWorkpoolPath) != null) {
                                 List<String> workPool = curator.getChildren().forPath(assignedWorkpoolPath);
                                 if (workPool.contains(searchedWorkItem)) {
@@ -97,15 +97,15 @@ public class WorkPooledMultiJobIT extends AbstractJobManagerTest {
         ) {
             assertTimeout(Duration.ofMillis(30_000),
                     () -> {
-                        if (proxiedCurator.checkExists().forPath(paths.toAssignedWorkItems(worker1, getJobId(1)))
+                        if (proxiedCurator.checkExists().forPath(paths.assignedWorkItems(worker1, getJobId(1)))
                                 != null &&
-                                proxiedCurator.checkExists().forPath(paths.toAssignedWorkItems(worker2, getJobId
+                                proxiedCurator.checkExists().forPath(paths.assignedWorkItems(worker2, getJobId
                                         (1))) != null) {
                             Set<String> workItems = getWorkItems(1);
                             List<String> workPool1 = proxiedCurator.getChildren().forPath(paths
-                                    .toAssignedWorkItems(worker1, getJobId(1)));
+                                    .assignedWorkItems(worker1, getJobId(1)));
                             List<String> workPool2 = proxiedCurator.getChildren().forPath(paths
-                                    .toAssignedWorkItems(worker2, getJobId(1)));
+                                    .assignedWorkItems(worker2, getJobId(1)));
                             workItems.removeAll(workPool1);
                             workItems.removeAll(workPool2);
                             return workItems.isEmpty();
@@ -123,23 +123,23 @@ public class WorkPooledMultiJobIT extends AbstractJobManagerTest {
 
             assertTimeout(Duration.ofMillis(30_000),
                     () -> {
-                        if (zkTestingServer.getClient().checkExists().forPath(paths.toAssignedWorkItems(worker2,
+                        if (zkTestingServer.getClient().checkExists().forPath(paths.assignedWorkItems(worker2,
                                 getJobId(1))) != null) {
                             Set<String> workItems = getWorkItems(1);
 
                             List<String> workPool1 = new ArrayList<>();
-                            if (zkTestingServer.getClient().checkExists().forPath(paths.toAssignedWorkItems
+                            if (zkTestingServer.getClient().checkExists().forPath(paths.assignedWorkItems
                                     (worker1, getJobId(1))) != null) {
                                 try {
                                     workPool1.addAll(zkTestingServer.getClient().getChildren().forPath(paths
-                                            .toAssignedWorkItems(worker1, getJobId(1))));
+                                            .assignedWorkItems(worker1, getJobId(1))));
                                 } catch (KeeperException.NoNodeException e) {
                                     // ignore this exception here
                                 }
                             }
 
                             List<String> workPool2 = zkTestingServer.getClient().getChildren().forPath(paths
-                                    .toAssignedWorkItems(worker2, getJobId(1)));
+                                    .assignedWorkItems(worker2, getJobId(1)));
                             return workPool1.isEmpty() && workPool2.containsAll(workItems);
                         }
                         return false;
@@ -159,15 +159,15 @@ public class WorkPooledMultiJobIT extends AbstractJobManagerTest {
 
             assertTimeout(Duration.ofMillis(50_000),
                     () -> {
-                        if (proxiedCurator.checkExists().forPath(paths.toAssignedWorkItems(worker1, getJobId(1)))
+                        if (proxiedCurator.checkExists().forPath(paths.assignedWorkItems(worker1, getJobId(1)))
                                 != null &&
-                                proxiedCurator.checkExists().forPath(paths.toAssignedWorkItems(worker2, getJobId
+                                proxiedCurator.checkExists().forPath(paths.assignedWorkItems(worker2, getJobId
                                         (1))) != null) {
                             Set<String> workItems = getWorkItems(1);
                             List<String> workPool1 = proxiedCurator.getChildren().forPath(paths
-                                    .toAssignedWorkItems(worker1, getJobId(1)));
+                                    .assignedWorkItems(worker1, getJobId(1)));
                             List<String> workPool2 = proxiedCurator.getChildren().forPath(paths
-                                    .toAssignedWorkItems(worker2, getJobId(1)));
+                                    .assignedWorkItems(worker2, getJobId(1)));
                             workItems.removeAll(workPool1);
                             workItems.removeAll(workPool2);
                             return workItems.isEmpty() && !workPool1.isEmpty();
@@ -189,8 +189,8 @@ public class WorkPooledMultiJobIT extends AbstractJobManagerTest {
         ) {
             assertTimeout(Duration.ofMillis(10_000),
                     () -> {
-                        String pathForWorker1 = paths.toAssignedWorkItems(nodeIds[0], getJobId(1));
-                        String pathForWorker2 = paths.toAssignedWorkItems(nodeIds[1], getJobId(1));
+                        String pathForWorker1 = paths.assignedWorkItems(nodeIds[0], getJobId(1));
+                        String pathForWorker2 = paths.assignedWorkItems(nodeIds[1], getJobId(1));
 
                         if (curator.checkExists().forPath(pathForWorker1) != null && curator.checkExists().forPath
                                 (pathForWorker2) != null) {
@@ -330,7 +330,7 @@ public class WorkPooledMultiJobIT extends AbstractJobManagerTest {
 
         ZkPathsManager paths = new ZkPathsManager(JOB_MANAGER_ZK_ROOT_PATH);
         // simulate hard shutdown where availability is not cleaned up
-        String availableWorkpoolPath = paths.toAvailableWorkItems(nodeId, testJob.getJobId());
+        String availableWorkpoolPath = paths.availableWorkItems(nodeId, testJob.getJobId());
         zkTestingServer.getClient().create().creatingParentsIfNeeded().forPath(availableWorkpoolPath);
 
         try (
@@ -591,7 +591,7 @@ public class WorkPooledMultiJobIT extends AbstractJobManagerTest {
             assertTimeout(Duration.ofMillis(30_000),
                     () -> {
                         List<String> workPoolForFirstJob = curator2.getChildren()
-                                .forPath(paths.toAssignedWorkItems(nodeIds[1], getJobId(1)));
+                                .forPath(paths.assignedWorkItems(nodeIds[1], getJobId(1)));
                         return workPoolForFirstJob.size() == getWorkItems(1).size();
                     },
                     () -> "All work pool should be distributed on 1 alive worker" + printZkTree

--- a/distributed-job-manager/src/test/java/ru/fix/distributed/job/manager/WorkShareLockServiceTest.java
+++ b/distributed-job-manager/src/test/java/ru/fix/distributed/job/manager/WorkShareLockServiceTest.java
@@ -28,7 +28,7 @@ public class WorkShareLockServiceTest extends AbstractJobManagerTest {
         final String rootPath = "/test";
         try (
                 CuratorFramework curator = zkTestingServer.createClient();
-                WorkShareLockServiceImpl workShareLockService = new WorkShareLockServiceImpl(curator, new JobManagerPaths
+                WorkShareLockServiceImpl workShareLockService = new WorkShareLockServiceImpl(curator, new ZkPathsManager
                         (rootPath), nodeId, new AggregatingProfiler())
         ) {
             ListenerManager<ConnectionStateListener, ConnectionStateListener> listenableBefore =
@@ -55,7 +55,7 @@ public class WorkShareLockServiceTest extends AbstractJobManagerTest {
         try (
                 CuratorFramework curator = zkTestingServer.createClient();
                 WorkShareLockServiceImpl workShareLockService = new WorkShareLockServiceImpl(curator,
-                        new JobManagerPaths(rootPath), nodeId, new AggregatingProfiler())
+                        new ZkPathsManager(rootPath), nodeId, new AggregatingProfiler())
         ) {
             boolean beforeAcquire = workShareLockService.existsLock(new SimpleJob(), "item");
             assertThat(beforeAcquire, is(false));

--- a/distributed-job-manager/src/test/kotlin/ru/fix/distributed/job/manager/DistributedJobManagerTest.kt
+++ b/distributed-job-manager/src/test/kotlin/ru/fix/distributed/job/manager/DistributedJobManagerTest.kt
@@ -93,7 +93,7 @@ internal class DistributedJobManagerTest : AbstractJobManagerTest() {
         createDjmWithEvenlySpread("worker-1", listOf(distributedJobs()[1]))
         createDjmWithEvenlySpread("worker-2", listOf(distributedJobs()[2]))
         awaitPathInit(listOf(
-                paths.getAssignedWorkItemPath("worker-2", "distr-job-id-2", "distr-job-id-2.work-item-0")
+                paths.toAssignedWorkItem("worker-2", "distr-job-id-2", "distr-job-id-2.work-item-0")
         ))
 
         val assignedState = readAssignedState(zkTestingServer.createClient())
@@ -108,11 +108,11 @@ internal class DistributedJobManagerTest : AbstractJobManagerTest() {
         createDjmWithEvenlySpread("worker-0", distributedJobs())
         createDjmWithEvenlySpread("worker-1", distributedJobs())
         awaitPathInit(listOf(
-                paths.getAssignedWorkItemPath("worker-1", "distr-job-id-1", "distr-job-id-1.work-item-1")
+                paths.toAssignedWorkItem("worker-1", "distr-job-id-1", "distr-job-id-1.work-item-1")
         ))
         createDjmWithEvenlySpread("worker-2", distributedJobs())
         awaitPathInit(listOf(
-                paths.getAssignedWorkItemPath("worker-2", "distr-job-id-1", "distr-job-id-1.work-item-5")
+                paths.toAssignedWorkItem("worker-2", "distr-job-id-1", "distr-job-id-1.work-item-5")
         ))
 
         val curatorFramework = zkTestingServer.createClient()
@@ -127,7 +127,7 @@ internal class DistributedJobManagerTest : AbstractJobManagerTest() {
         createDjmWithRendezvous("worker-1", listOf(distributedJobs()[1]))
         createDjmWithRendezvous("worker-2", listOf(distributedJobs()[2]))
         awaitPathInit(listOf(
-                paths.getAssignedWorkItemPath("worker-2", "distr-job-id-2", "distr-job-id-2.work-item-0")
+                paths.toAssignedWorkItem("worker-2", "distr-job-id-2", "distr-job-id-2.work-item-0")
         ))
 
         val curatorFramework = zkTestingServer.createClient()
@@ -144,21 +144,21 @@ internal class DistributedJobManagerTest : AbstractJobManagerTest() {
         createDjmWithRendezvous("worker-1", distributedJobs())
         createDjmWithRendezvous("worker-2", distributedJobs())
         awaitPathInit(listOf(
-                paths.getAssignedWorkItemPath("worker-2", "distr-job-id-1", "distr-job-id-1.work-item-1")
+                paths.toAssignedWorkItem("worker-2", "distr-job-id-1", "distr-job-id-1.work-item-1")
         ))
 
         val nodes = listOf(
-                paths.getAssignedWorkItemPath("worker-1", "distr-job-id-1", "distr-job-id-1.work-item-0"),
-                paths.getAssignedWorkItemPath("worker-1", "distr-job-id-0", "distr-job-id-0.work-item-0"),
-                paths.getAssignedWorkItemPath("worker-1", "distr-job-id-2", "distr-job-id-2.work-item-1"),
+                paths.toAssignedWorkItem("worker-1", "distr-job-id-1", "distr-job-id-1.work-item-0"),
+                paths.toAssignedWorkItem("worker-1", "distr-job-id-0", "distr-job-id-0.work-item-0"),
+                paths.toAssignedWorkItem("worker-1", "distr-job-id-2", "distr-job-id-2.work-item-1"),
 
-                paths.getAssignedWorkItemPath("worker-0", "distr-job-id-1", "distr-job-id-1.work-item-5"),
-                paths.getAssignedWorkItemPath("worker-0", "distr-job-id-1", "distr-job-id-1.work-item-2"),
-                paths.getAssignedWorkItemPath("worker-0", "distr-job-id-1", "distr-job-id-1.work-item-3"),
+                paths.toAssignedWorkItem("worker-0", "distr-job-id-1", "distr-job-id-1.work-item-5"),
+                paths.toAssignedWorkItem("worker-0", "distr-job-id-1", "distr-job-id-1.work-item-2"),
+                paths.toAssignedWorkItem("worker-0", "distr-job-id-1", "distr-job-id-1.work-item-3"),
 
-                paths.getAssignedWorkItemPath("worker-2", "distr-job-id-2", "distr-job-id-2.work-item-0"),
-                paths.getAssignedWorkItemPath("worker-2", "distr-job-id-1", "distr-job-id-1.work-item-4"),
-                paths.getAssignedWorkItemPath("worker-2", "distr-job-id-1", "distr-job-id-1.work-item-1")
+                paths.toAssignedWorkItem("worker-2", "distr-job-id-2", "distr-job-id-2.work-item-0"),
+                paths.toAssignedWorkItem("worker-2", "distr-job-id-1", "distr-job-id-1.work-item-4"),
+                paths.toAssignedWorkItem("worker-2", "distr-job-id-1", "distr-job-id-1.work-item-1")
         )
 
         val curator = zkTestingServer.createClient()
@@ -245,7 +245,7 @@ internal class DistributedJobManagerTest : AbstractJobManagerTest() {
         createDjm("worker-2", listOf<DistributedJob>(smsJob, ussdJob, rebillJob), customStrategy)
         createDjm("worker-3", listOf<DistributedJob>(smsJob, ussdJob, rebillJob), customStrategy)
         awaitPathInit(listOf(
-                paths.getAssignedWorkItemPath("worker-3", "distr-job-id-0", "distr-job-id-0.work-item-2")
+                paths.toAssignedWorkItem("worker-3", "distr-job-id-0", "distr-job-id-0.work-item-2")
         ))
 
         val curatorFramework = zkTestingServer.createClient()
@@ -268,7 +268,7 @@ internal class DistributedJobManagerTest : AbstractJobManagerTest() {
     private fun workersAlive(vararg workers: String): Boolean {
         val curator = zkTestingServer.createClient()
         workers.forEach {
-            val path = JobManagerPaths(JOB_MANAGER_ZK_ROOT_PATH).getWorkerAliveFlagPath(it)
+            val path = JobManagerPaths(JOB_MANAGER_ZK_ROOT_PATH).toAliveWorker(it)
             if (curator.checkExists().forPath(path) == null) {
                 return false
             }
@@ -309,20 +309,20 @@ internal class DistributedJobManagerTest : AbstractJobManagerTest() {
     private fun readAvailableState(curatorFramework: CuratorFramework): AssignmentState {
         val availableState = AssignmentState()
         val workersRoots = curatorFramework.children
-                .forPath(paths.workersPath)
+                .forPath(paths.toAllWorkers())
 
         for (worker in workersRoots) {
-            if (curatorFramework.checkExists().forPath(paths.getWorkerAliveFlagPath(worker)) == null) {
+            if (curatorFramework.checkExists().forPath(paths.toAliveWorker(worker)) == null) {
                 continue
             }
 
             val availableJobIds = curatorFramework.children
-                    .forPath(paths.getAvailableWorkPooledJobPath(worker))
+                    .forPath(paths.toAvailableJobs(worker))
 
             val availableWorkPool = HashSet<WorkItem>()
             for (availableJobId in availableJobIds) {
                 val workItemsForAvailableJobList = curatorFramework.children
-                        .forPath(paths.getAvailableWorkPoolPath(worker, availableJobId))
+                        .forPath(paths.toAvailableWorkItems(worker, availableJobId))
 
                 for (workItem in workItemsForAvailableJobList) {
                     availableWorkPool.add(WorkItem(workItem, JobId(availableJobId)))
@@ -336,16 +336,16 @@ internal class DistributedJobManagerTest : AbstractJobManagerTest() {
     private fun readAssignedState(curatorFramework: CuratorFramework): AssignmentState {
         val assignedState = AssignmentState()
 
-        val workersRoots = curatorFramework.children.forPath(paths.workersPath)
+        val workersRoots = curatorFramework.children.forPath(paths.toAllWorkers())
 
         for (worker in workersRoots) {
             val assignedJobIds = curatorFramework.children
-                    .forPath(paths.getAssignedWorkPooledJobsPath(worker))
+                    .forPath(paths.toAssignedJobs(worker))
 
             val assignedWorkPool = HashSet<WorkItem>()
             for (assignedJobId in assignedJobIds) {
                 val assignedJobWorkItems = curatorFramework.children
-                        .forPath(paths.getAssignedWorkPoolPath(worker, assignedJobId))
+                        .forPath(paths.toAssignedWorkItems(worker, assignedJobId))
 
                 for (workItem in assignedJobWorkItems) {
                     assignedWorkPool.add(WorkItem(workItem, JobId(assignedJobId)))

--- a/distributed-job-manager/src/test/kotlin/ru/fix/distributed/job/manager/DistributedJobManagerTest.kt
+++ b/distributed-job-manager/src/test/kotlin/ru/fix/distributed/job/manager/DistributedJobManagerTest.kt
@@ -322,7 +322,7 @@ internal class DistributedJobManagerTest : AbstractJobManagerTest() {
             val availableWorkPool = HashSet<WorkItem>()
             for (availableJobId in availableJobIds) {
                 val workItemsForAvailableJobList = curatorFramework.children
-                        .forPath(paths.availableWorkItems(worker, availableJobId))
+                        .forPath(paths.availableWorkPool(worker, availableJobId))
 
                 for (workItem in workItemsForAvailableJobList) {
                     availableWorkPool.add(WorkItem(workItem, JobId(availableJobId)))
@@ -345,7 +345,7 @@ internal class DistributedJobManagerTest : AbstractJobManagerTest() {
             val assignedWorkPool = HashSet<WorkItem>()
             for (assignedJobId in assignedJobIds) {
                 val assignedJobWorkItems = curatorFramework.children
-                        .forPath(paths.assignedWorkItems(worker, assignedJobId))
+                        .forPath(paths.assignedWorkPool(worker, assignedJobId))
 
                 for (workItem in assignedJobWorkItems) {
                     assignedWorkPool.add(WorkItem(workItem, JobId(assignedJobId)))

--- a/distributed-job-manager/src/test/kotlin/ru/fix/distributed/job/manager/DistributedJobManagerTest.kt
+++ b/distributed-job-manager/src/test/kotlin/ru/fix/distributed/job/manager/DistributedJobManagerTest.kt
@@ -93,7 +93,7 @@ internal class DistributedJobManagerTest : AbstractJobManagerTest() {
         createDjmWithEvenlySpread("worker-1", listOf(distributedJobs()[1]))
         createDjmWithEvenlySpread("worker-2", listOf(distributedJobs()[2]))
         awaitPathInit(listOf(
-                paths.toAssignedWorkItem("worker-2", "distr-job-id-2", "distr-job-id-2.work-item-0")
+                paths.assignedWorkItem("worker-2", "distr-job-id-2", "distr-job-id-2.work-item-0")
         ))
 
         val assignedState = readAssignedState(zkTestingServer.createClient())
@@ -108,11 +108,11 @@ internal class DistributedJobManagerTest : AbstractJobManagerTest() {
         createDjmWithEvenlySpread("worker-0", distributedJobs())
         createDjmWithEvenlySpread("worker-1", distributedJobs())
         awaitPathInit(listOf(
-                paths.toAssignedWorkItem("worker-1", "distr-job-id-1", "distr-job-id-1.work-item-1")
+                paths.assignedWorkItem("worker-1", "distr-job-id-1", "distr-job-id-1.work-item-1")
         ))
         createDjmWithEvenlySpread("worker-2", distributedJobs())
         awaitPathInit(listOf(
-                paths.toAssignedWorkItem("worker-2", "distr-job-id-1", "distr-job-id-1.work-item-5")
+                paths.assignedWorkItem("worker-2", "distr-job-id-1", "distr-job-id-1.work-item-5")
         ))
 
         val curatorFramework = zkTestingServer.createClient()
@@ -127,7 +127,7 @@ internal class DistributedJobManagerTest : AbstractJobManagerTest() {
         createDjmWithRendezvous("worker-1", listOf(distributedJobs()[1]))
         createDjmWithRendezvous("worker-2", listOf(distributedJobs()[2]))
         awaitPathInit(listOf(
-                paths.toAssignedWorkItem("worker-2", "distr-job-id-2", "distr-job-id-2.work-item-0")
+                paths.assignedWorkItem("worker-2", "distr-job-id-2", "distr-job-id-2.work-item-0")
         ))
 
         val curatorFramework = zkTestingServer.createClient()
@@ -144,21 +144,21 @@ internal class DistributedJobManagerTest : AbstractJobManagerTest() {
         createDjmWithRendezvous("worker-1", distributedJobs())
         createDjmWithRendezvous("worker-2", distributedJobs())
         awaitPathInit(listOf(
-                paths.toAssignedWorkItem("worker-2", "distr-job-id-1", "distr-job-id-1.work-item-1")
+                paths.assignedWorkItem("worker-2", "distr-job-id-1", "distr-job-id-1.work-item-1")
         ))
 
         val nodes = listOf(
-                paths.toAssignedWorkItem("worker-1", "distr-job-id-1", "distr-job-id-1.work-item-0"),
-                paths.toAssignedWorkItem("worker-1", "distr-job-id-0", "distr-job-id-0.work-item-0"),
-                paths.toAssignedWorkItem("worker-1", "distr-job-id-2", "distr-job-id-2.work-item-1"),
+                paths.assignedWorkItem("worker-1", "distr-job-id-1", "distr-job-id-1.work-item-0"),
+                paths.assignedWorkItem("worker-1", "distr-job-id-0", "distr-job-id-0.work-item-0"),
+                paths.assignedWorkItem("worker-1", "distr-job-id-2", "distr-job-id-2.work-item-1"),
 
-                paths.toAssignedWorkItem("worker-0", "distr-job-id-1", "distr-job-id-1.work-item-5"),
-                paths.toAssignedWorkItem("worker-0", "distr-job-id-1", "distr-job-id-1.work-item-2"),
-                paths.toAssignedWorkItem("worker-0", "distr-job-id-1", "distr-job-id-1.work-item-3"),
+                paths.assignedWorkItem("worker-0", "distr-job-id-1", "distr-job-id-1.work-item-5"),
+                paths.assignedWorkItem("worker-0", "distr-job-id-1", "distr-job-id-1.work-item-2"),
+                paths.assignedWorkItem("worker-0", "distr-job-id-1", "distr-job-id-1.work-item-3"),
 
-                paths.toAssignedWorkItem("worker-2", "distr-job-id-2", "distr-job-id-2.work-item-0"),
-                paths.toAssignedWorkItem("worker-2", "distr-job-id-1", "distr-job-id-1.work-item-4"),
-                paths.toAssignedWorkItem("worker-2", "distr-job-id-1", "distr-job-id-1.work-item-1")
+                paths.assignedWorkItem("worker-2", "distr-job-id-2", "distr-job-id-2.work-item-0"),
+                paths.assignedWorkItem("worker-2", "distr-job-id-1", "distr-job-id-1.work-item-4"),
+                paths.assignedWorkItem("worker-2", "distr-job-id-1", "distr-job-id-1.work-item-1")
         )
 
         val curator = zkTestingServer.createClient()
@@ -245,7 +245,7 @@ internal class DistributedJobManagerTest : AbstractJobManagerTest() {
         createDjm("worker-2", listOf<DistributedJob>(smsJob, ussdJob, rebillJob), customStrategy)
         createDjm("worker-3", listOf<DistributedJob>(smsJob, ussdJob, rebillJob), customStrategy)
         awaitPathInit(listOf(
-                paths.toAssignedWorkItem("worker-3", "distr-job-id-0", "distr-job-id-0.work-item-2")
+                paths.assignedWorkItem("worker-3", "distr-job-id-0", "distr-job-id-0.work-item-2")
         ))
 
         val curatorFramework = zkTestingServer.createClient()
@@ -268,7 +268,7 @@ internal class DistributedJobManagerTest : AbstractJobManagerTest() {
     private fun workersAlive(vararg workers: String): Boolean {
         val curator = zkTestingServer.createClient()
         workers.forEach {
-            val path = ZkPathsManager(JOB_MANAGER_ZK_ROOT_PATH).toAliveWorker(it)
+            val path = ZkPathsManager(JOB_MANAGER_ZK_ROOT_PATH).aliveWorker(it)
             if (curator.checkExists().forPath(path) == null) {
                 return false
             }
@@ -309,20 +309,20 @@ internal class DistributedJobManagerTest : AbstractJobManagerTest() {
     private fun readAvailableState(curatorFramework: CuratorFramework): AssignmentState {
         val availableState = AssignmentState()
         val workersRoots = curatorFramework.children
-                .forPath(paths.toAllWorkers())
+                .forPath(paths.allWorkers())
 
         for (worker in workersRoots) {
-            if (curatorFramework.checkExists().forPath(paths.toAliveWorker(worker)) == null) {
+            if (curatorFramework.checkExists().forPath(paths.aliveWorker(worker)) == null) {
                 continue
             }
 
             val availableJobIds = curatorFramework.children
-                    .forPath(paths.toAvailableJobs(worker))
+                    .forPath(paths.availableJobs(worker))
 
             val availableWorkPool = HashSet<WorkItem>()
             for (availableJobId in availableJobIds) {
                 val workItemsForAvailableJobList = curatorFramework.children
-                        .forPath(paths.toAvailableWorkItems(worker, availableJobId))
+                        .forPath(paths.availableWorkItems(worker, availableJobId))
 
                 for (workItem in workItemsForAvailableJobList) {
                     availableWorkPool.add(WorkItem(workItem, JobId(availableJobId)))
@@ -336,16 +336,16 @@ internal class DistributedJobManagerTest : AbstractJobManagerTest() {
     private fun readAssignedState(curatorFramework: CuratorFramework): AssignmentState {
         val assignedState = AssignmentState()
 
-        val workersRoots = curatorFramework.children.forPath(paths.toAllWorkers())
+        val workersRoots = curatorFramework.children.forPath(paths.allWorkers())
 
         for (worker in workersRoots) {
             val assignedJobIds = curatorFramework.children
-                    .forPath(paths.toAssignedJobs(worker))
+                    .forPath(paths.assignedJobs(worker))
 
             val assignedWorkPool = HashSet<WorkItem>()
             for (assignedJobId in assignedJobIds) {
                 val assignedJobWorkItems = curatorFramework.children
-                        .forPath(paths.toAssignedWorkItems(worker, assignedJobId))
+                        .forPath(paths.assignedWorkItems(worker, assignedJobId))
 
                 for (workItem in assignedJobWorkItems) {
                     assignedWorkPool.add(WorkItem(workItem, JobId(assignedJobId)))

--- a/distributed-job-manager/src/test/kotlin/ru/fix/distributed/job/manager/DistributedJobManagerTest.kt
+++ b/distributed-job-manager/src/test/kotlin/ru/fix/distributed/job/manager/DistributedJobManagerTest.kt
@@ -268,7 +268,7 @@ internal class DistributedJobManagerTest : AbstractJobManagerTest() {
     private fun workersAlive(vararg workers: String): Boolean {
         val curator = zkTestingServer.createClient()
         workers.forEach {
-            val path = JobManagerPaths(JOB_MANAGER_ZK_ROOT_PATH).toAliveWorker(it)
+            val path = ZkPathsManager(JOB_MANAGER_ZK_ROOT_PATH).toAliveWorker(it)
             if (curator.checkExists().forPath(path) == null) {
                 return false
             }


### PR DESCRIPTION
Blocked by https://github.com/ru-fix/distributed-job-manager/pull/23.
See https://github.com/ru-fix/distributed-job-manager/issues/22.
In this pull-request I just rename methods by `refactor`->`rename` feature in Intellij Idea IDE

After conversation i also renamed `JobManagerPaths`  to `ZkPathsManager`