### PR TITLE
Issue 5 remove redundant work pool prefixes in zk tree

### DIFF
--- a/asciidoc/index.adoc
+++ b/asciidoc/index.adoc
@@ -136,12 +136,11 @@ job-manager
     └ 3  //worker with id 3
     ...
   └ locks //locks guard work-items: ony one Job can access work-item in the same time
-    └ work-pooled
-      └ async.report.building.job //job id
-        └ workItemA.lock  //list of job locks so only one node could run job with same work-item
-      └ elasticsearch.upload.job
-        └ workItemC.lock
-        ...
+    └ async.report.building.job //job id
+      └ workItemA.lock  //list of job locks so only one node could run job with same work-item
+    └ elasticsearch.upload.job
+      └ workItemC.lock
+      ...
   └ assignment-version //part of transaction, allows atomicaly assign jobs
   └ registration-version //part of transaction, allows atomicaly register workier
   └ leader-latch // used for Manager election
@@ -151,25 +150,19 @@ job-manager
      ...
     └ 3
       └ available //list of jobs that worker with id `3` can run
-        └ work-pooled
-          └ async.report.building.job
-            └ work-pool
-              └ workItemA //Work pool of report.building Job
-              └ workItemB
-          └ elasticsearch.upload.job
-            └ work-pool
-              └ workItemC
-           ...
-      └ assigned
-        └ work-pooled                   //List of assigned jobs to worker '3'
-          └ async.report.building.job
-            └ work-pool
-              └ workItemA  //report.building job with `workItemA` and `workItemB` is assigned to worker `3`
-              └ workItemB
-          └ elasticsearch.upload.job
-            └ work-pool
-              └ workItemC
-           ...
+        └ async.report.building.job
+          └ workItemA //Work pool of report.building Job
+          └ workItemB
+        └ elasticsearch.upload.job
+          └ workItemC
+         ...
+      └ assigned                 //List of assigned jobs to worker '3'
+        └ async.report.building.job
+          └ workItemA  //report.building job with `workItemA` and `workItemB` is assigned to worker `3`
+          └ workItemB
+        └ elasticsearch.upload.job
+          └ workItemC
+         ...
 ```
 
 == Guarantees

--- a/distributed-job-manager/src/main/java/ru/fix/distributed/job/manager/DistributedJobManager.java
+++ b/distributed-job-manager/src/main/java/ru/fix/distributed/job/manager/DistributedJobManager.java
@@ -26,12 +26,12 @@ import java.util.Collection;
  * starts local Worker so Node can work as worker and as a manager.
  * <br>
  * Every worker provide unique id and register as child node at /workers <br>
- * Every worker register available jobs classes that it can run in /workers/worker-id/available/work-pooled/job-id <br>
+ * Every worker register available jobs classes that it can run in /workers/worker-id/available/job-id <br>
  * All workers should register same SchedulableJobs.
- * Avery worker listen to /workers/id/assigned/work-pooled. New schedulable job will be added there by Manager. <br>
- * When new assigned job appears, worker acquire lock /jobs/work-pooled/job-id.lock and start launching it with given
+ * Avery worker listen to /workers/id/assigned. New schedulable job will be added there by Manager. <br>
+ * When new assigned job appears, worker acquire lock /jobs/job-id.lock and start launching it with given
  * delay.
- * When job disappears from worker assigned/work-pooled path, worker stop executing job and release job lock.
+ * When job disappears from worker /assigned path, worker stop executing job and release job lock.
  * </p>
  * <p>
  * ZK node tree managed by {@link DistributedJobManager} described in {@link JobManagerPaths}

--- a/distributed-job-manager/src/main/java/ru/fix/distributed/job/manager/JobManagerPaths.java
+++ b/distributed-job-manager/src/main/java/ru/fix/distributed/job/manager/JobManagerPaths.java
@@ -37,12 +37,11 @@ class JobManagerPaths {
     }
 
     String toLocks() {
-        return ZKPaths.makePath(rootPath, LOCKS, WORK_POOLED_JOB_ID);
+        return ZKPaths.makePath(rootPath, LOCKS);
     }
 
     String toWorkItemLock(String jobId, String workItem) {
-        return ZKPaths.makePath(rootPath, LOCKS, WORK_POOLED_JOB_ID, jobId,
-                String.format("work-share-%s.lock", workItem));
+        return ZKPaths.makePath(rootPath, LOCKS, jobId, String.format("work-share-%s.lock", workItem));
     }
 
     String toRegistrationVersion() {

--- a/distributed-job-manager/src/main/java/ru/fix/distributed/job/manager/JobManagerPaths.java
+++ b/distributed-job-manager/src/main/java/ru/fix/distributed/job/manager/JobManagerPaths.java
@@ -11,7 +11,6 @@ class JobManagerPaths {
     public static final String WORKERS = "workers";
     public static final String ASSIGNED = "assigned";
     public static final String AVAILABLE = "available";
-    public static final String WORK_POOLED_JOB_ID = "work-pooled";
     public static final String WORK_POOL = "work-pool";
 
     final String rootPath;
@@ -56,40 +55,32 @@ class JobManagerPaths {
         return ZKPaths.makePath(rootPath, WORKERS, workerId);
     }
 
-    String toAssignedWorkPool(String workerId) {
+    String toAssignedJobs(String workerId) {
         return ZKPaths.makePath(rootPath, WORKERS, workerId, ASSIGNED);
     }
 
-    String toAssignedJobs(String workerId) {
-        return ZKPaths.makePath(rootPath, WORKERS, workerId, ASSIGNED, WORK_POOLED_JOB_ID);
-    }
-
     String toAssignedWorkPool(String workerId, String jobId) {
-        return ZKPaths.makePath(rootPath, WORKERS, workerId, ASSIGNED, WORK_POOLED_JOB_ID, jobId);
+        return ZKPaths.makePath(rootPath, WORKERS, workerId, ASSIGNED, jobId);
     }
 
     String toAssignedWorkItems(String workerId, String jobId) {
-        return ZKPaths.makePath(rootPath, WORKERS, workerId, ASSIGNED, WORK_POOLED_JOB_ID, jobId, WORK_POOL);
+        return ZKPaths.makePath(rootPath, WORKERS, workerId, ASSIGNED, jobId, WORK_POOL);
     }
 
     String toAssignedWorkItem(String workerId, String jobId, String workItemId) {
-        return ZKPaths.makePath(rootPath, WORKERS, workerId, ASSIGNED, WORK_POOLED_JOB_ID, jobId, WORK_POOL, workItemId);
-    }
-
-    String toAvailableWorkPool(String workerId) {
-        return ZKPaths.makePath(rootPath, WORKERS, workerId, AVAILABLE);
+        return ZKPaths.makePath(rootPath, WORKERS, workerId, ASSIGNED, jobId, WORK_POOL, workItemId);
     }
 
     String toAvailableJobs(String workerId) {
-        return ZKPaths.makePath(rootPath, WORKERS, workerId, AVAILABLE, WORK_POOLED_JOB_ID);
+        return ZKPaths.makePath(rootPath, WORKERS, workerId, AVAILABLE);
     }
 
     String toAvailableWorkItems(String workerId, String jobId) {
-        return ZKPaths.makePath(rootPath, WORKERS, workerId, AVAILABLE, WORK_POOLED_JOB_ID, jobId, WORK_POOL);
+        return ZKPaths.makePath(rootPath, WORKERS, workerId, AVAILABLE, jobId, WORK_POOL);
     }
 
     String toAvailableWorkItem(String workerId, String jobId, String workItemId) {
-        return ZKPaths.makePath(rootPath, WORKERS, workerId, AVAILABLE, WORK_POOLED_JOB_ID, jobId, WORK_POOL, workItemId);
+        return ZKPaths.makePath(rootPath, WORKERS, workerId, AVAILABLE, jobId, WORK_POOL, workItemId);
     }
 
 }

--- a/distributed-job-manager/src/main/java/ru/fix/distributed/job/manager/JobManagerPaths.java
+++ b/distributed-job-manager/src/main/java/ru/fix/distributed/job/manager/JobManagerPaths.java
@@ -59,16 +59,12 @@ class JobManagerPaths {
         return ZKPaths.makePath(rootPath, WORKERS, workerId, ASSIGNED);
     }
 
-    String toAssignedWorkPool(String workerId, String jobId) {
+    String toAssignedWorkItems(String workerId, String jobId) {
         return ZKPaths.makePath(rootPath, WORKERS, workerId, ASSIGNED, jobId);
     }
 
-    String toAssignedWorkItems(String workerId, String jobId) {
-        return ZKPaths.makePath(rootPath, WORKERS, workerId, ASSIGNED, jobId, WORK_POOL);
-    }
-
     String toAssignedWorkItem(String workerId, String jobId, String workItemId) {
-        return ZKPaths.makePath(rootPath, WORKERS, workerId, ASSIGNED, jobId, WORK_POOL, workItemId);
+        return ZKPaths.makePath(rootPath, WORKERS, workerId, ASSIGNED, jobId, workItemId);
     }
 
     String toAvailableJobs(String workerId) {

--- a/distributed-job-manager/src/main/java/ru/fix/distributed/job/manager/JobManagerPaths.java
+++ b/distributed-job-manager/src/main/java/ru/fix/distributed/job/manager/JobManagerPaths.java
@@ -11,7 +11,6 @@ class JobManagerPaths {
     public static final String WORKERS = "workers";
     public static final String ASSIGNED = "assigned";
     public static final String AVAILABLE = "available";
-    public static final String WORK_POOL = "work-pool";
 
     final String rootPath;
 
@@ -72,11 +71,11 @@ class JobManagerPaths {
     }
 
     String toAvailableWorkItems(String workerId, String jobId) {
-        return ZKPaths.makePath(rootPath, WORKERS, workerId, AVAILABLE, jobId, WORK_POOL);
+        return ZKPaths.makePath(rootPath, WORKERS, workerId, AVAILABLE, jobId);
     }
 
     String toAvailableWorkItem(String workerId, String jobId, String workItemId) {
-        return ZKPaths.makePath(rootPath, WORKERS, workerId, AVAILABLE, jobId, WORK_POOL, workItemId);
+        return ZKPaths.makePath(rootPath, WORKERS, workerId, AVAILABLE, jobId, workItemId);
     }
 
 }

--- a/distributed-job-manager/src/main/java/ru/fix/distributed/job/manager/Worker.java
+++ b/distributed-job-manager/src/main/java/ru/fix/distributed/job/manager/Worker.java
@@ -203,9 +203,7 @@ class Worker implements AutoCloseable {
 
                     // create availability and assignments directories
                     transaction.createPath(paths.toWorker(workerId));
-                    transaction.createPath(paths.toAvailableWorkPool(workerId));
                     transaction.createPath(paths.toAvailableJobs(workerId));
-                    transaction.createPath(paths.toAssignedWorkPool(workerId));
                     transaction.createPath(paths.toAssignedJobs(workerId));
 
                     // register work pooled jobs

--- a/distributed-job-manager/src/main/java/ru/fix/distributed/job/manager/Worker.java
+++ b/distributed-job-manager/src/main/java/ru/fix/distributed/job/manager/Worker.java
@@ -208,13 +208,12 @@ class Worker implements AutoCloseable {
 
                     // register work pooled jobs
                     for (DistributedJob job : availableJobs) {
-                        transaction.createPath(
-                                ZKPaths.makePath(paths.toAvailableJobs(workerId), job.getJobId()));
                         transaction.createPath(paths.toAvailableWorkItems(workerId, job.getJobId()));
 
                         for (String workPool : workPools.get(job).getItems()) {
                             transaction.createPath(
-                                    ZKPaths.makePath(paths.toAvailableWorkItems(workerId, job.getJobId()), workPool));
+                                    paths.toAvailableWorkItem(workerId, job.getJobId(), workPool)
+                            );
                         }
                     }
                 }

--- a/docs/index.html
+++ b/docs/index.html
@@ -746,12 +746,11 @@ Worker listens for updates in assigned subtree and stop/launch jobs accordingly.
     └ 3  //worker with id 3
     ...
   └ locks //locks guard work-items: ony one Job can access work-item in the same time
-    └ work-pooled
-      └ async.report.building.job //job id
-        └ workItemA.lock  //list of job locks so only one node could run job with same work-item
-      └ elasticsearch.upload.job
-        └ workItemC.lock
-        ...
+    └ async.report.building.job //job id
+      └ workItemA.lock  //list of job locks so only one node could run job with same work-item
+    └ elasticsearch.upload.job
+      └ workItemC.lock
+      ...
   └ assignment-version //part of transaction, allows atomicaly assign jobs
   └ registration-version //part of transaction, allows atomicaly register workier
   └ leader-latch // used for Manager election
@@ -761,24 +760,18 @@ Worker listens for updates in assigned subtree and stop/launch jobs accordingly.
      ...
     └ 3
       └ available //list of jobs that worker with id `3` can run
-        └ work-pooled
-          └ async.report.building.job
-            └ work-pool
-              └ workItemA //Work pool of report.building Job
-              └ workItemB
-          └ elasticsearch.upload.job
-            └ work-pool
-              └ workItemC
-           ...
-      └ assigned
-        └ work-pooled                   //List of assigned jobs to worker '3'
-          └ async.report.building.job
-            └ work-pool
-              └ workItemA  //report.building job with `workItemA` and `workItemB` is assigned to worker `3`
-              └ workItemB
-          └ elasticsearch.upload.job
-            └ work-pool
-              └ workItemC
+        └ async.report.building.job
+          └ workItemA //Work pool of report.building Job
+          └ workItemB
+        └ elasticsearch.upload.job
+          └ workItemC
+         ...
+      └ assigned   //List of assigned jobs to worker '3'
+        └ async.report.building.job
+          └ workItemA  //report.building job with `workItemA` and `workItemB` is assigned to worker `3`
+          └ workItemB
+        └ elasticsearch.upload.job
+          └ workItemC
            ...</code></pre>
 </div>
 </div>


### PR DESCRIPTION
Blocked by https://github.com/ru-fix/distributed-job-manager/pull/24.
See https://github.com/ru-fix/distributed-job-manager/issues/5.
