### PR TITLE
issue-26 make DistributedJob#getWorkpoolCheckPeriod not default

### DIFF
--- a/distributed-job-manager/src/main/java/ru/fix/distributed/job/manager/DistributedJob.java
+++ b/distributed-job-manager/src/main/java/ru/fix/distributed/job/manager/DistributedJob.java
@@ -49,7 +49,5 @@ public interface DistributedJob {
      *
      * @return period of time in milliseconds, 0 means that work pool never expires and there is no need to check
      */
-    default long getWorkPoolCheckPeriod() {
-        return 0;
-    }
+    long getWorkPoolCheckPeriod();
 }

--- a/distributed-job-manager/src/test/java/ru/fix/distributed/job/manager/WorkPooledMultiJobSharingIT.java
+++ b/distributed-job-manager/src/test/java/ru/fix/distributed/job/manager/WorkPooledMultiJobSharingIT.java
@@ -72,5 +72,11 @@ class WorkPooledMultiJobSharingIT extends AbstractJobManagerTest {
         public void run(DistributedJobContext context) {
             monitor.check(context.getWorkShare());
         }
+
+        @Override
+        public long getWorkPoolCheckPeriod() {
+            return 0;
+        }
+
     }
 }

--- a/distributed-job-manager/src/test/java/ru/fix/distributed/job/manager/WorkShareLockServiceTest.java
+++ b/distributed-job-manager/src/test/java/ru/fix/distributed/job/manager/WorkShareLockServiceTest.java
@@ -118,6 +118,11 @@ public class WorkShareLockServiceTest extends AbstractJobManagerTest {
             return WorkPoolRunningStrategies.getSingleThreadStrategy();
         }
 
+        @Override
+        public long getWorkPoolCheckPeriod() {
+            return 0;
+        }
+
     }
 
 }

--- a/distributed-job-manager/src/test/kotlin/ru/fix/distributed/job/manager/example/DjmConfigurationExample.kt
+++ b/distributed-job-manager/src/test/kotlin/ru/fix/distributed/job/manager/example/DjmConfigurationExample.kt
@@ -35,6 +35,10 @@ class RebillJob : DistributedJob {
     override fun getWorkPoolRunningStrategy(): WorkPoolRunningStrategy? {
         return null
     }
+
+    override fun getWorkPoolCheckPeriod(): Long {
+        return 0
+    }
     //...
 }
 
@@ -59,6 +63,10 @@ class SmsJob : DistributedJob {
     override fun getWorkPoolRunningStrategy(): WorkPoolRunningStrategy? {
         return null
     }
+
+    override fun getWorkPoolCheckPeriod(): Long {
+        return 0
+    }
     // ...
 }
 
@@ -82,6 +90,10 @@ class UssdJob : DistributedJob {
 
     override fun getWorkPoolRunningStrategy(): WorkPoolRunningStrategy? {
         return null
+    }
+
+    override fun getWorkPoolCheckPeriod(): Long {
+        return 0
     }
 }
 


### PR DESCRIPTION
See https://github.com/ru-fix/distributed-job-manager/issues/26
