### PR TITLE
fix unstable JobManagerSettingsIT verifying

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ jobs:
       if: tag IS blank
       install: skip
       before_script: if [[ $encrypted_47596ca1f42f_key ]]; then openssl aes-256-cbc -K $encrypted_47596ca1f42f_key -iv $encrypted_47596ca1f42f_iv -in secring.gpg.enc -out secring.gpg -d; fi
-      script: ./gradlew clean build --warn
+      script: ./gradlew clean build
 
     - stage: deploy
       if: tag =~ ^\d+\.\d+\.\d+$

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -197,8 +197,11 @@ subprojects {
             maxParallelForks = 10
 
             testLogging {
-                events(TestLogEvent.PASSED, TestLogEvent.FAILED, TestLogEvent.SKIPPED)
+                events(TestLogEvent.FAILED)
                 showStandardStreams = true
+                showExceptions = true
+                showCauses = true
+                showStackTraces = true
                 exceptionFormat = TestExceptionFormat.FULL
             }
         }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -199,9 +199,6 @@ subprojects {
             testLogging {
                 events(TestLogEvent.FAILED)
                 showStandardStreams = false
-                showExceptions = true
-                showCauses = true
-                showStackTraces = true
                 exceptionFormat = TestExceptionFormat.FULL
             }
         }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -198,7 +198,7 @@ subprojects {
 
             testLogging {
                 events(TestLogEvent.FAILED)
-                showStandardStreams = true
+                showStandardStreams = false
                 showExceptions = true
                 showCauses = true
                 showStackTraces = true

--- a/distributed-job-manager/src/test/kotlin/ru/fix/distributed/job/manager/JobManagerSettingsIT.kt
+++ b/distributed-job-manager/src/test/kotlin/ru/fix/distributed/job/manager/JobManagerSettingsIT.kt
@@ -47,15 +47,14 @@ internal class JobManagerSettingsIT : AbstractJobManagerTest() {
             }
             settingsEditor.setDisableAllJobProperty(false)
             await().atMost(defaultJobRunTimeout).untilAsserted {
-                verify(job1, times(2)).run(any())
-                verify(job2, times(2)).run(any())
+                verify(job1, atLeast(2)).run(any())
+                verify(job2, atLeast(2)).run(any())
             }
         }
     }
 
     @Test
     fun `WHEN jobs disable switches changed THEN jobs running accordingly`() {
-        val jobRunTimeout = Duration.ofSeconds(4)
         val job1 = spy(createStubbedJob(1))
         val job2 = spy(createStubbedJob(2))
         val settingsEditor = JobManagerSettingsEditor()
@@ -64,24 +63,24 @@ internal class JobManagerSettingsIT : AbstractJobManagerTest() {
                 settingsEditor = settingsEditor,
                 jobs = listOf(job1, job2)
         ).use {
-            await().atMost(jobRunTimeout).untilAsserted {
+            await().atMost(defaultJobRunTimeout).untilAsserted {
                 verify(job1, never()).run(any())
                 verify(job2, times(1)).run(any())
             }
             settingsEditor.disableConcreteJob(job2)
-            await().pollDelay(jobRunTimeout).untilAsserted {
+            await().pollDelay(defaultJobRunTimeout).untilAsserted {
                 verify(job1, never()).run(any())
                 verify(job2, times(1)).run(any())
             }
             settingsEditor.enableConcreteJob(job1)
-            await().atMost(jobRunTimeout).untilAsserted {
+            await().atMost(defaultJobRunTimeout).untilAsserted {
                 verify(job1, times(1)).run(any())
                 verify(job2, times(1)).run(any())
             }
             settingsEditor.enableConcreteJob(job2)
-            await().atMost(jobRunTimeout).untilAsserted {
-                verify(job1, times(2)).run(any())
-                verify(job2, times(2)).run(any())
+            await().atMost(defaultJobRunTimeout).untilAsserted {
+                verify(job1, atLeast(2)).run(any())
+                verify(job2, atLeast(2)).run(any())
             }
         }
     }
@@ -109,7 +108,7 @@ internal class JobManagerSettingsIT : AbstractJobManagerTest() {
     private fun createStubbedJob(
             jobId: Int = 1,
             workItems: Set<String> = setOf("1", "2"),
-            delay: Long = 100,
+            delay: Long = 500,
             workPoolCheckPeriod: Long = 0
     ): StubbedMultiJob = StubbedMultiJob(
             jobId, workItems, delay, workPoolCheckPeriod


### PR DESCRIPTION
second job may be launched during verifying first job :( 

I changed verification for testing that both jobs became enabled and were launched at least one more time. Increased timeouts for second test are not needed. 

Blocked by https://github.com/ru-fix/distributed-job-manager/pull/62