### PR TITLE
add logging failed tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ jobs:
       if: tag IS blank
       install: skip
       before_script: if [[ $encrypted_47596ca1f42f_key ]]; then openssl aes-256-cbc -K $encrypted_47596ca1f42f_key -iv $encrypted_47596ca1f42f_iv -in secring.gpg.enc -out secring.gpg -d; fi
-      script: ./gradlew clean build --warn
+      script: ./gradlew clean build
 
     - stage: deploy
       if: tag =~ ^\d+\.\d+\.\d+$

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -197,8 +197,11 @@ subprojects {
             maxParallelForks = 10
 
             testLogging {
-                events(TestLogEvent.PASSED, TestLogEvent.FAILED, TestLogEvent.SKIPPED)
+                events(TestLogEvent.FAILED)
                 showStandardStreams = true
+                showExceptions = true
+                showCauses = true
+                showStackTraces = true
                 exceptionFormat = TestExceptionFormat.FULL
             }
         }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -199,9 +199,6 @@ subprojects {
             testLogging {
                 events(TestLogEvent.FAILED)
                 showStandardStreams = false
-                showExceptions = true
-                showCauses = true
-                showStackTraces = true
                 exceptionFormat = TestExceptionFormat.FULL
             }
         }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -198,7 +198,7 @@ subprojects {
 
             testLogging {
                 events(TestLogEvent.FAILED)
-                showStandardStreams = true
+                showStandardStreams = false
                 showExceptions = true
                 showCauses = true
                 showStackTraces = true


### PR DESCRIPTION
Currently we print all tests results (success, failed, skipped), but log-level in travis-ci build is set to WARN. So we can't see failed tests in travis-ci logs when build is failed. 

I suggest set log-level to default and print only failed tests results