### PR TITLE
Evenly spread assigment strategy test failure due to assigment state logic

### DIFF
--- a/distributed-job-manager/src/main/java/ru/fix/distributed/job/manager/model/AssignmentState.java
+++ b/distributed-job-manager/src/main/java/ru/fix/distributed/job/manager/model/AssignmentState.java
@@ -93,9 +93,9 @@ public class AssignmentState extends HashMap<WorkerId, HashSet<WorkItem>> {
 
             boolean localWorkPoolLessThanMin = localWorkPoolSizeOnWorker < minLocalWorkPoolSizeOnWorker;
             boolean localWorkPoolEqualMin = localWorkPoolSizeOnWorker == minLocalWorkPoolSizeOnWorker;
-            boolean globalWorkPoolLessThanMin = globalWorkPoolSizeOnWorker < minGlobalWorkPoolSizeOnWorker;
+            boolean globalWorkPoolLessOrEqualMin = globalWorkPoolSizeOnWorker <= minGlobalWorkPoolSizeOnWorker;
 
-            if (localWorkPoolLessThanMin || (localWorkPoolEqualMin && globalWorkPoolLessThanMin)) {
+            if (localWorkPoolLessThanMin || (localWorkPoolEqualMin && globalWorkPoolLessOrEqualMin)) {
                 minLocalWorkPoolSizeOnWorker = localWorkPoolSizeOnWorker;
                 minGlobalWorkPoolSizeOnWorker = globalWorkPoolSizeOnWorker;
                 localLessBusyWorker = worker.getKey();

--- a/distributed-job-manager/src/main/java/ru/fix/distributed/job/manager/model/AssignmentState.java
+++ b/distributed-job-manager/src/main/java/ru/fix/distributed/job/manager/model/AssignmentState.java
@@ -75,7 +75,8 @@ public class AssignmentState extends HashMap<WorkerId, HashSet<WorkItem>> {
      * @param jobId            job name for filtering work items on worker
      * @param availableWorkers set of workers, that should be considered
      * @return worker from availableWorkers, that have
-     * minimal work pool size of jobId and minimal work pool size on worker
+     * minimal work pool size of jobId
+     * and minimal work pool size on worker, if work pool sized of jobId are equal,
      * or return null, if assignment state or availableWorkers are empty
      */
     public WorkerId getLessBusyWorkerWithJobId(JobId jobId, Set<WorkerId> availableWorkers) {
@@ -90,12 +91,14 @@ public class AssignmentState extends HashMap<WorkerId, HashSet<WorkItem>> {
             int localWorkPoolSizeOnWorker = localPoolSize(jobId, worker.getKey());
             int globalWorkPoolSizeOnWorker = worker.getValue().size();
 
-            if (localWorkPoolSizeOnWorker <= minLocalWorkPoolSizeOnWorker) {
-                if (globalWorkPoolSizeOnWorker <= minGlobalWorkPoolSizeOnWorker) {
-                    minLocalWorkPoolSizeOnWorker = localWorkPoolSizeOnWorker;
-                    minGlobalWorkPoolSizeOnWorker = globalWorkPoolSizeOnWorker;
-                    localLessBusyWorker = worker.getKey();
-                }
+            boolean localWorkPoolLessThanMin = localWorkPoolSizeOnWorker < minLocalWorkPoolSizeOnWorker;
+            boolean localWorkPoolEqualMin = localWorkPoolSizeOnWorker == minLocalWorkPoolSizeOnWorker;
+            boolean globalWorkPoolLessThanMin = globalWorkPoolSizeOnWorker < minGlobalWorkPoolSizeOnWorker;
+
+            if (localWorkPoolLessThanMin || (localWorkPoolEqualMin && globalWorkPoolLessThanMin)) {
+                minLocalWorkPoolSizeOnWorker = localWorkPoolSizeOnWorker;
+                minGlobalWorkPoolSizeOnWorker = globalWorkPoolSizeOnWorker;
+                localLessBusyWorker = worker.getKey();
             }
         }
         return localLessBusyWorker;
@@ -331,7 +334,6 @@ public class AssignmentState extends HashMap<WorkerId, HashSet<WorkItem>> {
     }
 
 
-
     @Override
     public String toString() {
         StringBuilder result = new StringBuilder("AssignmentState\n");
@@ -352,7 +354,6 @@ public class AssignmentState extends HashMap<WorkerId, HashSet<WorkItem>> {
         }
         return result.toString();
     }
-
 
 
 }

--- a/distributed-job-manager/src/main/java/ru/fix/distributed/job/manager/model/AssignmentState.java
+++ b/distributed-job-manager/src/main/java/ru/fix/distributed/job/manager/model/AssignmentState.java
@@ -338,7 +338,7 @@ public class AssignmentState extends HashMap<WorkerId, HashSet<WorkItem>> {
     public String toString() {
         StringBuilder result = new StringBuilder("AssignmentState\n");
         List<Entry<WorkerId, HashSet<WorkItem>>> sortedAssignment = new ArrayList<>(entrySet());
-        sortedAssignment.sort(Comparator.comparing(Entry::getKey));
+        sortedAssignment.sort(Entry.comparingByKey());
 
         for (Map.Entry<WorkerId, HashSet<WorkItem>> worker : sortedAssignment) {
             String workerId = worker.getKey().getId();

--- a/distributed-job-manager/src/test/kotlin/ru/fix/distributed/job/manager/model/AssignmentStateTest.kt
+++ b/distributed-job-manager/src/test/kotlin/ru/fix/distributed/job/manager/model/AssignmentStateTest.kt
@@ -1,0 +1,47 @@
+package ru.fix.distributed.job.manager.model
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.util.*
+
+internal class AssignmentStateTest {
+
+    @Test
+    fun `getLessBusyWorkerWithJobId localWorkPool is more important than globalWorkPool`() {
+        val workerId0 = WorkerId("0")
+        val workerId1 = WorkerId("1")
+        val workerId2 = WorkerId("2")
+        val workerId3 = WorkerId("3")
+        val workerId4 = WorkerId("4")
+        val allWorkers = setOf(workerId0, workerId1, workerId2, workerId3, workerId4)
+
+        val jobId1 = JobId("1")
+        val jobId2 = JobId("2")
+
+        val state = AssignmentState()
+        state.putAll(mapOf(
+                worker(workerId0, items(jobId1, 56), items(jobId2, 6)),
+                worker(workerId1, items(jobId1, 58), items(jobId2, 4)),
+                worker(workerId2, items(jobId1, 57), items(jobId2, 4)),
+                worker(workerId3, items(jobId1, 57), items(jobId2, 4)),
+                worker(workerId4, items(jobId1, 57), items(jobId2, 5))
+        ))
+
+        assertEquals(workerId0, state.getLessBusyWorkerWithJobId(jobId1, allWorkers))
+    }
+
+
+    private fun worker(workerId: WorkerId, vararg jobs: HashSet<WorkItem>): Pair<WorkerId, HashSet<WorkItem>> {
+        val items = hashSetOf<WorkItem>()
+        jobs.forEach { items.addAll(it) }
+        return workerId to items
+    }
+
+    private fun items(jobId: JobId, count: Int): HashSet<WorkItem> {
+        val items = hashSetOf<WorkItem>()
+        repeat(count) {
+            items.add(WorkItem(UUID.randomUUID().toString(), jobId))
+        }
+        return items
+    }
+}

--- a/distributed-job-manager/src/test/kotlin/ru/fix/distributed/job/manager/model/AssignmentStateTest.kt
+++ b/distributed-job-manager/src/test/kotlin/ru/fix/distributed/job/manager/model/AssignmentStateTest.kt
@@ -7,7 +7,7 @@ import java.util.*
 internal class AssignmentStateTest {
 
     @Test
-    fun `getLessBusyWorkerWithJobId localWorkPool is more important than globalWorkPool`() {
+    fun `getLessBusyWorkerWithJobId  WHEN job workPools sizes are different THEN global workPools sizes don't matter`() {
         val workerId0 = WorkerId("0")
         val workerId1 = WorkerId("1")
         val workerId2 = WorkerId("2")

--- a/distributed-job-manager/src/test/kotlin/ru/fix/distributed/job/manager/model/AssignmentStateTest.kt
+++ b/distributed-job-manager/src/test/kotlin/ru/fix/distributed/job/manager/model/AssignmentStateTest.kt
@@ -11,20 +11,16 @@ internal class AssignmentStateTest {
         val workerId0 = WorkerId("0")
         val workerId1 = WorkerId("1")
         val workerId2 = WorkerId("2")
-        val workerId3 = WorkerId("3")
-        val workerId4 = WorkerId("4")
-        val allWorkers = setOf(workerId0, workerId1, workerId2, workerId3, workerId4)
+        val allWorkers = setOf(workerId0, workerId1, workerId2)
 
         val jobId1 = JobId("1")
         val jobId2 = JobId("2")
 
         val state = AssignmentState()
         state.putAll(mapOf(
-                worker(workerId0, items(jobId1, 56), items(jobId2, 6)),
-                worker(workerId1, items(jobId1, 58), items(jobId2, 4)),
-                worker(workerId2, items(jobId1, 57), items(jobId2, 4)),
-                worker(workerId3, items(jobId1, 57), items(jobId2, 4)),
-                worker(workerId4, items(jobId1, 57), items(jobId2, 5))
+                worker(workerId0, items(jobId1, 0), items(jobId2, 2)),
+                worker(workerId1, items(jobId1, 2), items(jobId2, 0)),
+                worker(workerId2, items(jobId1, 1), items(jobId2, 0))
         ))
 
         assertEquals(workerId0, state.getLessBusyWorkerWithJobId(jobId1, allWorkers))


### PR DESCRIPTION
now `EvenlySpreadAssignmentStrategy#reassignAndBalance`  falls into infinity loop during `ReassignmentNumberComparisonTest#shutdown all workers except one and start all 8 workers again` test:
![Screenshot from 2020-07-18 18-47-18](https://user-images.githubusercontent.com/28933068/87856553-98f09580-c928-11ea-838e-73317c9931ff.png)
It happens because `AssignmentState#getLessBusyWorkerWithJobId` works incorrectly, i think. We should compare globalWorkPoolSizeOnWorker with minGlobalWorkPoolSizeOnWorker only if localWorkPoolSizeOnWorker is equal to minLocalWorkPoolSizeOnWorker