### PR TITLE
make profiler, jfix-zookeeper, dp-api and curator dependencies transitive

### DIFF
--- a/distributed-job-manager/build.gradle.kts
+++ b/distributed-job-manager/build.gradle.kts
@@ -8,18 +8,18 @@ dependencies {
     implementation(Libs.kotlin_jdk8)
 
     // JFIX
-    implementation(Libs.aggregating_profiler)
-    implementation(Libs.jfix_zookeeper) {
+    api(Libs.aggregating_profiler)
+    api(Libs.jfix_zookeeper) {
         exclude("org.apache.curator", "curator-recipes")
     }
     implementation(Libs.jfix_concurrency)
-    implementation(Libs.jfix_dynamic_property_api)
+    api(Libs.jfix_dynamic_property_api)
 
     // Common
     implementation(Libs.slf4j)
     implementation(Libs.log4j_kotlin)
     implementation(Libs.validation_api)
-    implementation(Libs.curator) {
+    api(Libs.curator) {
         exclude("org.slf4j", "slf4j-api")
     }
 


### PR DESCRIPTION
DJM constructor is part of ABI, so dependencies which are used in parameters of that constructor should be in `api` scope