### PR TITLE
Shutdown jobs according to disableJobsConfig

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -18,7 +18,7 @@ object Vers {
     const val curator = "5.0.0"
 
     const val junit = "5.6.2"
-    const val mockito = "3.3.3"
+    const val mockk = "1.10.5"
     const val mockito_kotlin = "2.2.0"
     const val awaitility = "4.0.3"
 
@@ -43,7 +43,6 @@ object Libs {
     // JFIX
     const val aggregating_profiler = "ru.fix:aggregating-profiler:${Vers.aggregating_profiler}"
     const val jfix_zookeeper = "ru.fix:jfix-zookeeper:${Vers.jfix_zookeeper}"
-    const val jfix_zookeeper_test = "ru.fix:jfix-zookeeper-test:${Vers.jfix_zookeeper}"
     const val jfix_concurrency = "ru.fix:jfix-stdlib-concurrency:${Vers.jfix_stdlib}"
     const val jfix_dynamic_property_api = "ru.fix:dynamic-property-api:${Vers.jfix_dynamic_property}"
 
@@ -57,12 +56,12 @@ object Libs {
     const val slf4j_over_log4j = "org.apache.logging.log4j:log4j-slf4j-impl:${Vers.log4j}"
 
     // JFIX Test
-    const val jfix_socket = "ru.fix:jfix-stdlib-socket:${Vers.jfix_stdlib}"
+    const val jfix_zookeeper_test = "ru.fix:jfix-zookeeper-test:${Vers.jfix_zookeeper}"
 
     // Test
     const val junit_jupiter = "org.junit.jupiter:junit-jupiter:${Vers.junit}"
     const val curator_test = "org.apache.curator:curator-test:${Vers.curator}"
-    const val mockito = "org.mockito:mockito-core:${Vers.mockito}"
+    const val mockk = "io.mockk:mockk:${Vers.mockk}"
     const val mockito_kotlin = "com.nhaarman.mockitokotlin2:mockito-kotlin:${Vers.mockito_kotlin}"
     const val awaitility = "org.awaitility:awaitility:${Vers.awaitility}"
     const val kotest_assertions = "io.kotest:kotest-assertions-core:4.1.1"

--- a/distributed-job-manager/build.gradle.kts
+++ b/distributed-job-manager/build.gradle.kts
@@ -24,12 +24,11 @@ dependencies {
     }
 
     // JFIX Test
-    implementation(Libs.jfix_socket)
+    testImplementation(Libs.jfix_zookeeper_test)
 
     // Test
-    testImplementation(Libs.jfix_zookeeper_test)
     testImplementation(Libs.junit_jupiter)
-    testImplementation(Libs.mockito)
+    testImplementation(Libs.mockk)
     testImplementation(Libs.mockito_kotlin)
     testImplementation(Libs.curator_test)
     testImplementation(Libs.log4j_core)

--- a/distributed-job-manager/src/main/java/ru/fix/distributed/job/manager/Worker.java
+++ b/distributed-job-manager/src/main/java/ru/fix/distributed/job/manager/Worker.java
@@ -427,7 +427,6 @@ class Worker implements AutoCloseable {
                 new HashSet<>(workPoolToExecute),
                 profiler,
                 lockManager,
-                settings.map(DistributedJobManagerSettings::getJobDisableConfig),
                 paths
         );
 

--- a/distributed-job-manager/src/main/kotlin/ru/fix/distributed/job/manager/Manager.kt
+++ b/distributed-job-manager/src/main/kotlin/ru/fix/distributed/job/manager/Manager.kt
@@ -95,7 +95,7 @@ class Manager(
     private fun initSettingsSubscriptionForManagerEvents() {
         settingsSubscription.setAndCallListener { oldValue, newValue ->
             if(oldValue?.jobDisableConfig != newValue.jobDisableConfig) {
-                handleManagerEvent(ManagerEvent.ZK_WORKERS_CONFIG_CHANGED)
+                handleManagerEvent(ManagerEvent.JOB_DISABLE_CONFIG_CHANGED)
             }
         }
     }
@@ -144,7 +144,7 @@ class Manager(
 
     private fun handleManagerEventAsLeader(event: ManagerEvent) {
         when (event) {
-            ManagerEvent.ZK_WORKERS_CONFIG_CHANGED -> {
+            ManagerEvent.ZK_WORKERS_CONFIG_CHANGED, ManagerEvent.JOB_DISABLE_CONFIG_CHANGED -> {
                 rebalanceAccumulator.publishEvent(RebalanceTrigger.DO_REBALANCE)
             }
             ManagerEvent.LEADERSHIP_LOST -> {
@@ -161,7 +161,7 @@ class Manager(
 
     private fun handleManagerEventAsNonLeader(event: ManagerEvent) {
         when (event) {
-            ManagerEvent.ZK_WORKERS_CONFIG_CHANGED -> {
+            ManagerEvent.ZK_WORKERS_CONFIG_CHANGED, ManagerEvent.JOB_DISABLE_CONFIG_CHANGED -> {
             }
             ManagerEvent.LEADERSHIP_ACQUIRED -> {
                 currentState.set(State.IS_LEADER)
@@ -194,7 +194,7 @@ class Manager(
     }
 
     private enum class ManagerEvent {
-        ZK_WORKERS_CONFIG_CHANGED, LEADERSHIP_LOST, LEADERSHIP_ACQUIRED, SHUTDOWN
+        ZK_WORKERS_CONFIG_CHANGED, JOB_DISABLE_CONFIG_CHANGED, LEADERSHIP_LOST, LEADERSHIP_ACQUIRED, SHUTDOWN
     }
 
     private enum class RebalanceTrigger {


### PR DESCRIPTION
Client code should have possibility to react on disabling job in jobDisableConfig. I think manager should filter out disabled jobs before calculating new jobs assignment state, and also manager should trigger rebalance, when jobDisableConfig changed.