### PR TITLE
jfix-concurrency is exposed in api through use of Schedule in Distrib…

### DIFF
--- a/distributed-job-manager/build.gradle.kts
+++ b/distributed-job-manager/build.gradle.kts
@@ -12,7 +12,7 @@ dependencies {
     api(Libs.jfix_zookeeper) {
         exclude("org.apache.curator", "curator-recipes")
     }
-    implementation(Libs.jfix_concurrency)
+    api(Libs.jfix_concurrency)
     api(Libs.jfix_dynamic_property_api)
 
     // Common


### PR DESCRIPTION
…utedJob

If stated as implementation it forces to explicitly declare dependency on it.